### PR TITLE
Backup restore memory leak

### DIFF
--- a/nes_py/laines/cartridge.cpp
+++ b/nes_py/laines/cartridge.cpp
@@ -29,6 +29,10 @@ Cartridge::Cartridge(const char* file_name) {
     }
 }
 
+Cartridge::Cartridge(Cartridge* cart) {
+    mapper = cart->mapper->copy();
+};
+
 Cartridge::~Cartridge() {
     delete this->mapper;
 }

--- a/nes_py/laines/gamestate.cpp
+++ b/nes_py/laines/gamestate.cpp
@@ -7,10 +7,10 @@ GameState::GameState() {
 
 GameState::~GameState() {
     // delete cartridge;
-    // delete joypad;
-    // delete gui;
-    // delete ppu_state;
-    // delete cpu_state;
+    delete joypad;
+    delete gui;
+    delete ppu_state;
+    delete cpu_state;
 }
 
 GameState::GameState(GameState* state) {

--- a/nes_py/laines/gamestate.cpp
+++ b/nes_py/laines/gamestate.cpp
@@ -1,8 +1,8 @@
 #include "gamestate.hpp"
 
 GameState::GameState() {
-        ppu_state = new PPUState();
-        cpu_state = new CPUState();
+    ppu_state = new PPUState();
+    cpu_state = new CPUState();
 };
 
 GameState::~GameState() {

--- a/nes_py/laines/gamestate.cpp
+++ b/nes_py/laines/gamestate.cpp
@@ -21,14 +21,12 @@ GameState::GameState(GameState* state) {
     ppu_state = new PPUState(state->ppu_state);
 }
 
-void GameState::set_ppu_state(PPUState* new_ppu_state) {
-    delete ppu_state;
-    ppu_state = new_ppu_state;
-}
-
-void GameState::set_cpu_state(CPUState* new_cpu_state) {
-    delete cpu_state;
-    cpu_state = new_cpu_state;
+GameState::GameState(GameState* state, CPUState* cpu, PPUState* ppu) {
+    cartridge = new Cartridge(state->cartridge);
+    joypad = new Joypad(state->joypad);
+    gui = new GUI(state->gui);
+    cpu_state = cpu;
+    ppu_state = ppu;
 }
 
 void GameState::load() {

--- a/nes_py/laines/gamestate.cpp
+++ b/nes_py/laines/gamestate.cpp
@@ -21,6 +21,16 @@ GameState::GameState(GameState* state) {
     ppu_state = new PPUState(state->ppu_state);
 }
 
+void GameState::set_ppu_state(PPUState* new_ppu_state) {
+    delete ppu_state;
+    ppu_state = new_ppu_state;
+}
+
+void GameState::set_cpu_state(CPUState* new_cpu_state) {
+    delete cpu_state;
+    cpu_state = new_cpu_state;
+}
+
 void GameState::load() {
     // setup the CPU up
     CPU::set_state(cpu_state);

--- a/nes_py/laines/gamestate.cpp
+++ b/nes_py/laines/gamestate.cpp
@@ -1,5 +1,18 @@
 #include "gamestate.hpp"
 
+GameState::GameState() {
+        ppu_state = new PPUState();
+        cpu_state = new CPUState();
+};
+
+GameState::~GameState() {
+    // delete cartridge;
+    // delete joypad;
+    // delete gui;
+    // delete ppu_state;
+    // delete cpu_state;
+}
+
 GameState::GameState(GameState* state) {
     cartridge = new Cartridge(state->cartridge);
     joypad = new Joypad(state->joypad);

--- a/nes_py/laines/gamestate.cpp
+++ b/nes_py/laines/gamestate.cpp
@@ -6,7 +6,7 @@ GameState::GameState() {
 };
 
 GameState::~GameState() {
-    // delete cartridge;
+    delete cartridge;
     delete joypad;
     delete gui;
     delete ppu_state;

--- a/nes_py/laines/gui.cpp
+++ b/nes_py/laines/gui.cpp
@@ -1,8 +1,21 @@
 #include "gui.hpp"
 
-unsigned GUI::get_width() { return GUI::WIDTH; }
+GUI::GUI() {
 
-unsigned GUI::get_height() { return GUI::HEIGHT; }
+};
+
+GUI::GUI(GUI* gui) {
+    // copy the screen from the other GUI into this GUI
+    memcpy(screen, gui->screen, WIDTH * HEIGHT * sizeof(u32));
+};
+
+unsigned GUI::get_width() {
+    return GUI::WIDTH;
+}
+
+unsigned GUI::get_height() {
+    return GUI::HEIGHT;
+}
 
 void GUI::new_frame(u32* pixels) {
     // copy the pixels into the screen array (pointer)
@@ -10,5 +23,6 @@ void GUI::new_frame(u32* pixels) {
 }
 
 void GUI::copy_screen(unsigned char *output_buffer) {
+    // copy the screen into the output buffer
     memcpy(output_buffer, this->screen, this->WIDTH * this->HEIGHT * sizeof(u32));
 }

--- a/nes_py/laines/include/cartridge.hpp
+++ b/nes_py/laines/include/cartridge.hpp
@@ -17,9 +17,7 @@ public:
     Cartridge(const char* file_name);
 
     /// Initialize a cartridge as a copy of another
-    Cartridge(Cartridge* cart) {
-        mapper = cart->mapper->copy();
-    };
+    Cartridge(Cartridge* cart);
 
     /// Delete an instance of cartridge
     ~Cartridge();

--- a/nes_py/laines/include/gamestate.hpp
+++ b/nes_py/laines/include/gamestate.hpp
@@ -6,6 +6,12 @@
 
 /// a save state of the NES machine
 class GameState {
+private:
+    /// the state for the CPU
+    PPUState* ppu_state;
+    /// the state for the GPU
+    CPUState* cpu_state;
+
 public:
     /// the current game cartridge
     Cartridge* cartridge;
@@ -13,10 +19,6 @@ public:
     Joypad* joypad;
     /// the GUI for the game-state
     GUI* gui;
-    /// the state for the CPU
-    PPUState* ppu_state;
-    /// the state for the GPU
-    CPUState* cpu_state;
 
     /// Initialize a new game-state
     GameState();
@@ -24,6 +26,10 @@ public:
     ~GameState();
     /// create a new game-state as a copy of another
     GameState(GameState* state);
+    /// Set the PPU state to a new value
+    void set_ppu_state(PPUState* new_ppu_state);
+    /// Set the CPU state to a new value
+    void set_cpu_state(CPUState* new_cpu_state);
     /// Load the game-state's data into the machine
     void load();
 };

--- a/nes_py/laines/include/gamestate.hpp
+++ b/nes_py/laines/include/gamestate.hpp
@@ -19,10 +19,9 @@ public:
     CPUState* cpu_state;
 
     /// Initialize a new game-state
-    GameState() {
-        ppu_state = new PPUState();
-        cpu_state = new CPUState();
-    };
+    GameState();
+    /// Delete a gamestate
+    ~GameState();
     /// create a new game-state as a copy of another
     GameState(GameState* state);
     /// Load the game-state's data into the machine

--- a/nes_py/laines/include/gamestate.hpp
+++ b/nes_py/laines/include/gamestate.hpp
@@ -6,12 +6,6 @@
 
 /// a save state of the NES machine
 class GameState {
-private:
-    /// the state for the CPU
-    PPUState* ppu_state;
-    /// the state for the GPU
-    CPUState* cpu_state;
-
 public:
     /// the current game cartridge
     Cartridge* cartridge;
@@ -19,6 +13,10 @@ public:
     Joypad* joypad;
     /// the GUI for the game-state
     GUI* gui;
+    /// the state for the CPU
+    PPUState* ppu_state;
+    /// the state for the GPU
+    CPUState* cpu_state;
 
     /// Initialize a new game-state
     GameState();
@@ -26,10 +24,8 @@ public:
     ~GameState();
     /// create a new game-state as a copy of another
     GameState(GameState* state);
-    /// Set the PPU state to a new value
-    void set_ppu_state(PPUState* new_ppu_state);
-    /// Set the CPU state to a new value
-    void set_cpu_state(CPUState* new_cpu_state);
+    /// create a new game-state as a copy of another with different states
+    GameState(GameState* state, CPUState* new_cpu_state, PPUState* new_ppu_state);
     /// Load the game-state's data into the machine
     void load();
 };

--- a/nes_py/laines/include/gamestate.hpp
+++ b/nes_py/laines/include/gamestate.hpp
@@ -20,7 +20,7 @@ public:
 
     /// Initialize a new game-state
     GameState();
-    /// Delete a gamestate
+    /// Delete a game-state
     ~GameState();
     /// create a new game-state as a copy of another
     GameState(GameState* state);

--- a/nes_py/laines/include/gui.hpp
+++ b/nes_py/laines/include/gui.hpp
@@ -17,10 +17,10 @@ private:
 
 public:
     /// Initialize a new GUI.
-    GUI() { };
+    GUI();
 
     /// Initialize a new GUI as a copy of another GUI.
-    GUI(GUI* gui) { memcpy(screen, gui->screen, WIDTH * HEIGHT * sizeof(u32)); };
+    GUI(GUI* gui);
 
     /// Return the width of the screen.
     static unsigned get_width();

--- a/nes_py/laines/include/joypad.hpp
+++ b/nes_py/laines/include/joypad.hpp
@@ -18,28 +18,10 @@ private:
 public:
 
     /// Initialize a new joy-pad instance
-    Joypad() {
-        for (int i = 0; i < NUM_JOYPADS; i++) {
-            joypad_buttons[i] = 0;
-            joypad_bits[i] = 0;
-        }
-        strobe = false;
-    };
+    Joypad();
 
     /// Initialize a new joy-pad as a copy of another
-    Joypad(Joypad* joypad) {
-        std::copy(
-            std::begin(joypad->joypad_buttons),
-            std::end(joypad->joypad_buttons),
-            std::begin(joypad_buttons)
-        );
-        std::copy(
-            std::begin(joypad->joypad_bits),
-            std::end(joypad->joypad_bits),
-            std::begin(joypad_bits)
-        );
-        strobe = joypad->strobe;
-    };
+    Joypad(Joypad* joypad);
 
     /**
         Write a button state to the given joy-pad.

--- a/nes_py/laines/include/mapper.hpp
+++ b/nes_py/laines/include/mapper.hpp
@@ -3,8 +3,13 @@
 #include <cstring>
 #include "common.hpp"
 
+/// An abstract base class for a Mapper module on a Cartridge
 class Mapper {
+    /// the ROM this mapper is loading from
     u8* rom;
+    /// the size of the ROM in bytes
+    int romSize;
+    /// whether this mapper has CHR RAM
     bool chrRam = false;
 
 protected:

--- a/nes_py/laines/joypad.cpp
+++ b/nes_py/laines/joypad.cpp
@@ -1,5 +1,27 @@
 #include "joypad.hpp"
 
+Joypad::Joypad() {
+    for (int i = 0; i < NUM_JOYPADS; i++) {
+        joypad_buttons[i] = 0;
+        joypad_bits[i] = 0;
+    }
+    strobe = false;
+};
+
+Joypad::Joypad(Joypad* joypad) {
+    std::copy(
+        std::begin(joypad->joypad_buttons),
+        std::end(joypad->joypad_buttons),
+        std::begin(joypad_buttons)
+    );
+    std::copy(
+        std::begin(joypad->joypad_bits),
+        std::end(joypad->joypad_bits),
+        std::begin(joypad_bits)
+    );
+    strobe = joypad->strobe;
+};
+
 void Joypad::write_buttons(int n, u8 buttons) {
     this->joypad_buttons[n] = buttons;
 }

--- a/nes_py/laines/nes_env.cpp
+++ b/nes_py/laines/nes_env.cpp
@@ -32,8 +32,8 @@ void NESEnv::backup() {
     // copy the current state with the backup state
     delete backup_state;
     backup_state = new GameState(current_state);
-    backup_state->cpu_state = CPU::get_state();
-    backup_state->ppu_state = PPU::get_state();
+    backup_state->set_cpu_state(CPU::get_state());
+    backup_state->set_ppu_state(PPU::get_state());
 }
 
 void NESEnv::restore() {

--- a/nes_py/laines/nes_env.cpp
+++ b/nes_py/laines/nes_env.cpp
@@ -31,9 +31,7 @@ void NESEnv::step(unsigned char action) {
 void NESEnv::backup() {
     // copy the current state with the backup state
     delete backup_state;
-    backup_state = new GameState(current_state);
-    backup_state->set_cpu_state(CPU::get_state());
-    backup_state->set_ppu_state(PPU::get_state());
+    backup_state = new GameState(current_state, CPU::get_state(), PPU::get_state());
 }
 
 void NESEnv::restore() {

--- a/nes_py/laines/nes_env.cpp
+++ b/nes_py/laines/nes_env.cpp
@@ -30,6 +30,7 @@ void NESEnv::step(unsigned char action) {
 
 void NESEnv::backup() {
     // copy the current state with the backup state
+    delete backup_state;
     backup_state = new GameState(current_state);
     backup_state->cpu_state = CPU::get_state();
     backup_state->ppu_state = PPU::get_state();
@@ -37,6 +38,7 @@ void NESEnv::backup() {
 
 void NESEnv::restore() {
     // copy the backup state into the current state and load the machine
+    delete current_state;
     current_state = new GameState(backup_state);
     current_state->load();
 }

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ lib_nes_env = Extension(lib_name,
 
 setup(
     name='nes_py',
-    version='0.10.2',
+    version='0.10.3',
     description='An NES Emulator and OpenAI Gym interface',
     long_description=README(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
resolve memory leak in the backup / restore feature by deleting current state and backup state on call to restore and backup respectively. Update object with destructors where necessary and resolve an issue where mappers weren't being copied correctly