### PR TITLE
"LaiNES" ---> "SimpleNES" in nes.py

### DIFF
--- a/nes_py/nes_env.py
+++ b/nes_py/nes_env.py
@@ -80,7 +80,7 @@ CONTROLLER_VECTOR = ctypes.c_byte * 1
 
 
 class NESEnv(gym.Env):
-    """An NES environment based on the LaiNES emulator."""
+    """An NES environment based on the SimpleNES emulator."""
 
     # relevant meta-data about the environment
     metadata = {


### PR DESCRIPTION
### Description

Proposing a name change in the `nes.py`, since the project moved away from LaiNES to SimpleNES emulator (as mentioned in the project `README.md`)

### Type of change

Please select all relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
