### PR TITLE
Refactor frame display loop

### DIFF
--- a/nes_py/app/play_human.py
+++ b/nes_py/app/play_human.py
@@ -1,5 +1,6 @@
 """A method to play gym environments using human IO inputs."""
 import gym
+import time
 from pyglet import clock
 from .._image_viewer import ImageViewer
 
@@ -20,8 +21,6 @@ def play_human(env: gym.Env, callback=None):
         None
 
     """
-    # set the frame rate for pyglet
-    clock.set_fps_limit(env.metadata['video.frames_per_second'])
     # ensure the observation space is a box of pixels
     assert isinstance(env.observation_space, gym.spaces.box.Box)
     # ensure the observation space is either B&W pixels or RGB Pixels
@@ -46,9 +45,18 @@ def play_human(env: gym.Env, callback=None):
     )
     # create a done flag for the environment
     done = True
+    # prepare frame rate limiting
+    target_frame_duration = 1 / env.metadata['video.frames_per_second']
+    last_frame_time = 0
     # start the main game loop
     try:
         while True:
+            current_frame_time = time.time()
+            # limit frame rate
+            if last_frame_time + target_frame_duration > current_frame_time:
+                continue
+            # save frame beginning time for next refresh
+            last_frame_time = current_frame_time
             # clock tick
             clock.tick()
             # reset if the environment is done


### PR DESCRIPTION
clock.set_fps_limit was removed as it is deprecated in piglet >= 1.4.0.
Frame rate limiting is now done by skipping the loop until enough time
has passed.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

-   Fixes #<issue>

### Type of change

Please select all relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

### Test Configuration

-   Operating System:
-   Python version:
-   C++ compiler version:

### Checklist

- [ ] My code follows the [style guidelines of this project](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
