### PR TITLE
fix: compatibility for pypy interpreter

### DIFF
--- a/nes_py/nes_env.py
+++ b/nes_py/nes_env.py
@@ -69,7 +69,7 @@ SCREEN_SHAPE_24_BIT = SCREEN_HEIGHT, SCREEN_WIDTH, 3
 # shape of the screen as 32-bit RGB (C++ memory arrangement)
 SCREEN_SHAPE_32_BIT = SCREEN_HEIGHT, SCREEN_WIDTH, 4
 # create a type for the screen tensor matrix from C++
-SCREEN_TENSOR = ctypes.c_byte * np.prod(SCREEN_SHAPE_32_BIT)
+SCREEN_TENSOR = ctypes.c_byte * int(np.prod(SCREEN_SHAPE_32_BIT))
 
 
 # create a type for the RAM vector from C++


### PR DESCRIPTION
Added support for pypy 3.7

The pypy (https://www.pypy.org/#!) interpreter throws an error (Line 72 TypeError: Can't multiply a ctypes type by a non-integer) when running the nes_env.py file, mostly due to some slight differences in the pypy numpy implementation. This is a quick one line fix for this issue, that should not break functionality in any of the other interpreters. It is simply an int cast, and numpy.prod() will always return an int, so nothing should break.