### PR TITLE
fixed new gym API related to step() and reset()

### DIFF
--- a/nes_py/app/play_human.py
+++ b/nes_py/app/play_human.py
@@ -62,15 +62,15 @@ def play_human(env: gym.Env, callback=None):
             # reset if the environment is done
             if done:
                 done = False
-                state = env.reset()
+                state, _ = env.reset()
                 viewer.show(env.unwrapped.screen)
             # unwrap the action based on pressed relevant keys
             action = keys_to_action.get(viewer.pressed_keys, _NOP)
-            next_state, reward, done, _ = env.step(action)
+            next_state, reward, done, truncated, _ = env.step(action)
             viewer.show(env.unwrapped.screen)
             # pass the observation data through the callback
             if callback is not None:
-                callback(state, action, reward, done, next_state)
+                callback(state, action, reward, done, truncated, next_state)
             state = next_state
             # shutdown if the escape key is pressed
             if viewer.is_escape_pressed:

--- a/nes_py/app/play_random.py
+++ b/nes_py/app/play_random.py
@@ -19,9 +19,9 @@ def play_random(env, steps):
         progress = tqdm(range(steps))
         for _ in progress:
             if done:
-                _ = env.reset()
+                _, _ = env.reset()
             action = env.action_space.sample()
-            _, reward, done, info = env.step(action)
+            _, reward, done, _, info = env.step(action)
             progress.set_postfix(reward=reward, info=info)
             env.render()
     except KeyboardInterrupt:

--- a/nes_py/tests/test_multiple_makes.py
+++ b/nes_py/tests/test_multiple_makes.py
@@ -24,9 +24,9 @@ def play(steps):
     done = True
     for _ in range(steps):
         if done:
-            _ = env.reset()
+            _, _ = env.reset()
         action = env.action_space.sample()
-        _, _, done, _ = env.step(action)
+        _, _, done, _, _ = env.step(action)
     # close the environment
     env.close()
 
@@ -45,7 +45,7 @@ class ShouldMakeMultipleEnvironmentsParallel(object):
 
     def test(self):
         procs = [None] * self.num_execs
-        args = (self.steps, )
+        args = (self.steps,)
         # spawn the parallel instances
         for idx in range(self.num_execs):
             procs[idx] = self.parallel_initializer(target=play, args=args)
@@ -82,6 +82,6 @@ class ShouldMakeMultipleEnvironmentsSingleThread(TestCase):
         for _ in range(self.steps):
             for idx in range(self.num_envs):
                 if dones[idx]:
-                    _ = envs[idx].reset()
+                    _, _ = envs[idx].reset()
                 action = envs[idx].action_space.sample()
-                _, _, dones[idx], _ = envs[idx].step(action)
+                _, _, dones[idx], _, _ = envs[idx].step(action)

--- a/nes_py/tests/test_nes_env.py
+++ b/nes_py/tests/test_nes_env.py
@@ -79,7 +79,7 @@ class ShouldStepEnv(TestCase):
         for _ in range(500):
             if done:
                 # reset the environment and check the output value
-                state = env.reset()
+                state, _ = env.reset()
                 self.assertIsInstance(state, np.ndarray)
             # sample a random action and check it
             action = env.action_space.sample()
@@ -87,12 +87,13 @@ class ShouldStepEnv(TestCase):
             # take a step and check the outputs
             output = env.step(action)
             self.assertIsInstance(output, tuple)
-            self.assertEqual(4, len(output))
+            self.assertEqual(5, len(output))
             # check each output
-            state, reward, done, info = output
+            state, reward, done, truncated, info = output
             self.assertIsInstance(state, np.ndarray)
             self.assertIsInstance(reward, float)
             self.assertIsInstance(done, bool)
+            self.assertIsInstance(truncated, bool)
             self.assertIsInstance(info, dict)
             # check the render output
             render = env.render('rgb_array')
@@ -108,9 +109,9 @@ class ShouldStepEnvBackupRestore(TestCase):
 
         for _ in range(250):
             if done:
-                state = env.reset()
+                state, _ = env.reset()
                 done = False
-            state, _, done, _ = env.step(0)
+            state, _, done, _, _ = env.step(0)
 
         backup = state.copy()
 
@@ -120,7 +121,7 @@ class ShouldStepEnvBackupRestore(TestCase):
             if done:
                 state = env.reset()
                 done = False
-            state, _, done, _ = env.step(0)
+            state, _, done, _, _ = env.step(0)
 
         self.assertFalse(np.array_equal(backup, state))
         env._restore()

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -7,9 +7,9 @@ done = True
 try:
     for _ in tqdm.tqdm(range(5000)):
         if done:
-            state = env.reset()
+            state, _ = env.reset()
             done = False
         else:
-            state, reward, done, info = env.step(env.action_space.sample())
+            state, reward, done, truncated, info = env.step(env.action_space.sample())
 except KeyboardInterrupt:
     pass

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ LIB_NES_ENV = Extension(LIB_NAME,
 
 setup(
     name='nes_py',
-    version='8.2.1',
+    version='8.2.2',
     description='An NES Emulator and OpenAI Gym interface',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Description

There are several issues related to changes in API.  I re-adjusted all code, so it returned truncated in step and readjusted reset to match what the gym expected.   In parallel, fixed Mario env.  Note old code won't work with this since GYM now return five elements in a tuple vs. 4.  Same for reset.   I also re-adjusted all the unit tests and examples, so it matched and passed all tests. 

-   Fixes #Incorrect number of arguments from call to env.step(action) #119


### Type of change

Please select all relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x] Unit test
- [x] run gyp-super Mario ( with readjusted step /reset) and its unit test.

### Test Configuration

-   Operating System:  12.5.1 mac os
-   Python version: 3.10
-   C++ compiler version: Apple clang version 13.1.6 (clang-1316.0.21.2.5)
Target: x86_64-apple-darwin21.6.0
Thread model: posix

### Checklist

- [ x] My code follows the [style guidelines of this project](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
- [ x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
