### PR TITLE
Remove faulty override of reset method in JoypadSpace wrapper

### DIFF
--- a/nes_py/wrappers/joypad_space.py
+++ b/nes_py/wrappers/joypad_space.py
@@ -73,10 +73,6 @@ class JoypadSpace(Wrapper):
         # take the step and record the output
         return self.env.step(self._action_map[action])
 
-    def reset(self):
-        """Reset the environment and return the initial observation."""
-        return self.env.reset()
-
     def get_keys_to_action(self):
         """Return the dictionary of keyboard keys to actions."""
         # get the old mapping of keys to actions


### PR DESCRIPTION
### Description

Fixes [https://stackoverflow.com/questions/76509663/typeerror-joypadspace-reset-got-an-unexpected-keyword-argument-seed](https://stackoverflow.com/q/76509663/8601760).

`JoypadSpace` doesn't correctly override the `reset()` method of `Wrapper`.  
- `JoypadSpace` `reset()` [was implemented](https://github.com/Kautenja/nes-py/commit/8efb860bb472e99ebb909d8b475a532c11bfff4b) for `gym` 0.10.5 in nes-py 0.8.7 (Jul 2018).
- `Wrapper` `reset()` [was defined](https://github.com/openai/gym/commit/4c460ba6c8959dd8e0a03b13a1ca817da6d4074f) with `**kwargs` in `gym` 0.10.6 (Oct 2018).  
  Though at the time `Env` `reset()` did not accept any parameters.
- `Env` `reset()` [started to accept](https://github.com/openai/gym/commit/c36450671090e52243f44fbd20314dd07df6263c) `seed` parameter in `gym` 0.22.0 (Feb 2022).

Since nes-py now requires `gym>=0.17.2`, it is unnecessary to implement (override) `reset()` method.

### Type of change

Please select all relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Since nes-py now requires `gym>=0.17.2`, removing the method override is a non-breaking change.

### How Has This Been Tested?

Not tested yet (I'm not a nes-py user), but the fix is straightforward.

### Test Configuration

NIL.

### Checklist

- [x] My code follows the [style guidelines of this project](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
- [x] I have performed a self-review of my own code
- [N.A.] I have commented my code, particularly in hard-to-understand areas
- [N.A.] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
