### PR TITLE
Add nes-py native optimization and vector APIs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,10 @@ If applicable, add screenshots to help explain your problem.
 
 -   Operating System:
 -   Python version:
+-   `nes-py` version:
+-   Install method (`pip install`, editable install, source build, conda + pip, etc.):
 -   C++ compiler and version:
+-   If Linux: output of `strings /path/to/libstdc++.so.6 | grep GLIBCXX | tail` if relevant
 
 ### Additional context
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ pip install nes-py
 Python 3.13 or newer is required. The supported CI wheel targets are CPython
 3.13 and 3.14.
 
+Binary wheels are published for Linux, macOS, and Windows on those supported
+Python versions. If `pip` cannot find a compatible wheel for your interpreter
+or platform, it will fall back to a source build and therefore needs a working
+native C++ toolchain in the active environment.
+
 ### Debian
 
 Make sure you have the `clang++` compiler installed:
@@ -152,6 +157,23 @@ sudo apt-get install clang
 You'll need to install the Visual-Studio 17.0 tools for Windows installation.
 The [Visual Studio Community](https://visualstudio.microsoft.com/downloads/)
 package provides these tools for free.
+
+### Native Runtime Troubleshooting
+
+`nes-py` ships a native extension, so import-time loader failures usually point
+to a compiler-runtime mismatch rather than a Python API bug.
+
+- On Linux, errors mentioning `GLIBCXX_* not found` mean the active
+  `libstdc++.so.6` is older than the one expected by the installed wheel or
+  build artifacts. Update the environment's C++ runtime, use a newer
+  distribution/toolchain, or rebuild from source inside the target
+  environment with `pip install --no-binary nes-py nes-py`.
+- On Windows, build failures usually mean the MSVC C++ build tools are missing
+  from the selected Python environment. Install Visual Studio Build Tools 2022
+  or the full Visual Studio Community package with the desktop C++ workload.
+- If you are using `conda`, `venv`, or another isolated environment manager,
+  make sure the compiler runtime loaded at import time matches the Python
+  environment where `nes-py` was installed.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,39 @@ Gymnasium's default observation contract. Benchmark local workloads with:
 python3 -m nes_py.speedtest --rom <path_to_rom> --observation-profile --no-progress
 ```
 
+### Vector, RAM, and Snapshot Helpers
+
+Same-ROM training loops can opt into a native vector emulator that batches
+controller writes, frame stepping, observation copies, RAM readback, and
+per-slot resets without moving game-specific reward or info logic into
+`nes-py`:
+
+```python
+import numpy as np
+
+from nes_py.vector_env import VectorNESEmulator
+
+vector = VectorNESEmulator("<path_to_rom>", 4)
+vector.reset()
+screens = vector.step(np.array([0, 1, 2, 3], dtype=np.uint8))
+gray = vector.observation("grayscale")
+ram_values = vector.ram_values((0x0000, (0x0001, 2, "little")))
+snapshot = vector.dump_state(0)
+vector.load_state(0, snapshot)
+vector.close()
+```
+
+Scalar `NESEnv` also exposes `ram_values(specs, output=None)`,
+`dump_state()`, and `load_state(snapshot)`. Snapshots are opaque same-process
+checkpoint objects, not a stable cross-version save-state format.
+
+Design notes and benchmark decisions live in:
+
+- `docs/vector-native-emulator.md`
+- `docs/native-batch-ram-info-reads.md`
+- `docs/vector-throughput-instrumentation.md`
+- `docs/explicit-state-snapshot-api.md`
+
 ### Controls
 
 | Keyboard Key | NES Joypad    |
@@ -345,6 +378,14 @@ and vary by machine, compiler, runner load, and display settings; they are not
 correctness criteria. Backup and restore stress options use explicit interval
 semantics, so `--backup-interval 12` runs a backup at steps 12, 24, 36, and so
 on.
+
+Additional profiles are available for ML and vector workflows:
+
+```shell
+python -m nes_py.speedtest --rom nes_py/tests/games/super-mario-bros-1.nes --observation-profile --json --no-progress
+python -m nes_py.speedtest --rom nes_py/tests/games/super-mario-bros-1.nes --ram-profile --json --no-progress
+python -m nes_py.speedtest --rom nes_py/tests/games/super-mario-bros-1.nes --vector-profile --runs 5 --env-counts 1,2,4,8,16 --instrumentation --json --no-progress
+```
 
 ## Cartridge Mapper Compatibility
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,37 @@ while not (terminated or truncated):
 env.close()
 ```
 
+### ML Observation Helpers
+
+`NESEnv.step` and `render` in `rgb_array` mode keep returning the default
+`(240, 256, 3)` `uint8` RGB screen view. That view is zero-copy, but it is
+strided over the native 32-bit screen buffer. Training loops that need a
+C-contiguous RGB frame or a grayscale frame can opt into explicit copy helpers
+and reuse output buffers:
+
+```python
+import numpy as np
+
+from nes_py.nes_env import NESEnv
+from nes_py.nes_env import SCREEN_SHAPE_24_BIT
+from nes_py.nes_env import SCREEN_SHAPE_GRAYSCALE
+
+env = NESEnv("<path_to_rom>")
+rgb = np.empty(SCREEN_SHAPE_24_BIT, dtype=np.uint8)
+gray = np.empty(SCREEN_SHAPE_GRAYSCALE, dtype=np.uint8)
+
+observation, info = env.reset()
+contiguous_rgb = env.observation("rgb_array_contiguous", output=rgb)
+grayscale = env.observation("grayscale", output=gray)
+```
+
+The helpers are intended for measured ML pipelines, not as a replacement for
+Gymnasium's default observation contract. Benchmark local workloads with:
+
+```shell
+python3 -m nes_py.speedtest --rom <path_to_rom> --observation-profile --no-progress
+```
+
 ### Controls
 
 | Keyboard Key | NES Joypad    |

--- a/docs/explicit-state-snapshot-api.md
+++ b/docs/explicit-state-snapshot-api.md
@@ -1,0 +1,82 @@
+# Explicit State Snapshot API
+
+Spec 053 adds an opaque public snapshot API on top of the current
+mapper-aware native backup model.
+
+## API
+
+Scalar:
+
+```python
+snapshot = env.dump_state()
+env.load_state(snapshot)
+```
+
+Vector:
+
+```python
+snapshot = vector.dump_state(index)
+vector.load_state(index, snapshot)
+```
+
+Snapshots are Python-visible opaque objects backed by `NES::Emulator::Snapshot`.
+They are not NumPy views, raw pointers, or a stable cross-version save-state
+format. They are intended for same-process branching, reset-to-checkpoint,
+debugging, and vector reset plumbing.
+
+## Lifetime and Compatibility
+
+- A snapshot owns copies of CPU state, main-bus RAM, picture-bus RAM/palette,
+  PPU state including the screen buffer and render caches, and a cloned mapper.
+- Mapper callbacks are not copied. `load_state` clones the snapshot mapper into
+  the target emulator and rewires IRQ callbacks plus main/picture bus mapper
+  pointers.
+- Direct PRG and CHR read pages are refreshed by mapper rewiring. Picture-bus
+  mirroring is synchronized after load.
+- Existing `_backup()` and `_restore()` behavior is preserved and now uses the
+  same state composition internally.
+- Loading an invalid Python object raises `TypeError`; loading after close
+  raises `ValueError`.
+
+## Coverage
+
+Python tests round-trip snapshots across the supported public mapper fixtures:
+0, 1, 2, 3, 4, 5, 7, 9, and 69. The tests verify screen state, RAM state,
+controller-sensitive continuation behavior, mapper bank continuation, mirroring
+state through rendered continuation, and instruction-batched continuation.
+Existing backup/restore tests continue to exercise the private slot API.
+
+## Benchmark Summary
+
+Host: macOS-26.3 arm64, CPython 3.14.2, clang, editable release-extension
+build. ROM: `super-mario-bros-1.nes`. Command shape:
+
+```sh
+.venv/bin/python - <<'PY'
+from nes_py.nes_env import NESEnv
+# 5 runs, 200 measured iterations, 20 warmups:
+# measure dump_state, load_state, _backup/_restore, dump+load round trips.
+PY
+```
+
+Median latency:
+
+| Operation | Median us | Min | Max |
+| --- | ---: | ---: | ---: |
+| dump_state | 23.29 | 23.05 | 23.57 |
+| load_state | 10.05 | 9.30 | 10.85 |
+| _backup + _restore | 27.74 | 26.99 | 28.17 |
+| dump_state + load_state | 34.83 | 33.65 | 35.11 |
+
+The public snapshot round trip is slightly slower than the private slot because
+it allocates an independently owned snapshot object. Normal step-only
+throughput is unchanged because snapshots are opt-in and no frame path reads
+snapshot state.
+
+## Decision
+
+The snapshot API is kept for clearer state management and vector reset
+plumbing, not for raw backup/restore speed. It uses the existing safe
+mapper-clone architecture, avoids raw struct copying, keeps `_backup()` and
+`_restore()` intact, and provides a public checkpoint primitive without
+claiming stable serialization compatibility.

--- a/docs/mapper-direct-read-fast-paths.md
+++ b/docs/mapper-direct-read-fast-paths.md
@@ -1,0 +1,63 @@
+# Mapper Direct Read Fast Paths
+
+Spec 042 added mapper-provided direct read pages for common mapper PRG/CHR
+windows. `MainBus` caches four 8 KiB PRG-ROM pages for CPU `$8000-$ffff`
+reads, and `PictureBus` caches eight 1 KiB CHR pages for PPU `$0000-$1fff`
+reads. Mapper writes refresh both caches so bank-register changes are visible
+before the next bus read.
+
+The direct CHR cache is disabled when mapper-visible PPU address/read/write
+hooks or mapper nametable mapping are active. Expansion routing and PRG RAM
+continue to use the existing mapper methods. CHR RAM writes are still routed
+through `writeCHR`; the direct read pages point at the same CHR RAM storage
+when the mapper can provide a contiguous page safely.
+
+Rejected design: looking up a direct pointer through a virtual mapper method on
+every CPU/PPU read was not kept because it preserved the virtual dispatch cost
+this spec was intended to remove. Bus-side page caches keep the address hot path
+to an indexed pointer read while retaining mapper ownership of bank selection.
+
+## Commands
+
+```sh
+build/nes-emu-release/nes_emu_benchmarks --benchmark-samples 1 --benchmark-resamples 1
+.venv/bin/python -m nes_py.speedtest --rom nes_py/tests/games/super-mario-bros-1.nes --steps 1000 --warmup-steps 100 --json --no-progress
+.venv/bin/python -m nes_py.speedtest --rom nes_py/tests/games/the-legend-of-zelda.nes --steps 1000 --warmup-steps 100 --json --no-progress
+```
+
+The PRG-read baseline was captured from commit `a29f6b3` in a temporary
+worktree with only the new PRG benchmark harness applied, so it measured the old
+virtual `readPRG` path with the same benchmark body.
+
+## Native Mapper Read Stress
+
+| Profile | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| NROM PRG reads | 25.318 us | 18.651 us | -26.3% |
+| SxROM PRG reads | 26.109 us | 18.693 us | -28.4% |
+| UxROM PRG reads | 25.776 us | 18.818 us | -27.0% |
+| CNROM PRG reads | 25.193 us | 19.442 us | -22.8% |
+| NROM CHR reads | 20.526 us | 13.680 us | -33.4% |
+| SxROM CHR reads | 24.568 us | 12.992 us | -47.1% |
+| UxROM CHR reads | 18.388 us | 13.221 us | -28.1% |
+| CNROM CHR reads | 20.900 us | 12.784 us | -38.8% |
+
+## Representative Frames
+
+| ROM | Mapper | Before | After | Change |
+| --- | ---: | ---: | ---: | ---: |
+| `super-mario-bros-1.nes` | 0 | 720.609 us | 732.734 us | +1.7% |
+| `the-legend-of-zelda.nes` | 1 | 750.026 us | 742.651 us | -1.0% |
+| `mega-man.nes` | 2 | 426.234 us | 430.692 us | +1.0% |
+| `adventure-island.nes` | 3 | 416.942 us | 396.067 us | -5.0% |
+
+## Public Speedtest
+
+| ROM | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| `super-mario-bros-1.nes` | 1353.26 steps/s | 1495.08 steps/s | +10.5% |
+| `the-legend-of-zelda.nes` | 1478.61 steps/s | 1536.16 steps/s | +3.9% |
+
+The benchmark suite uses one Catch2 sample and one resample to match Ralph
+verification. Treat the full-frame rows as smoke-profile direction rather than a
+strict threshold; the read-stress rows isolate the intended fast path.

--- a/docs/ml-observation-fast-paths.md
+++ b/docs/ml-observation-fast-paths.md
@@ -1,0 +1,52 @@
+# ML Observation Fast Paths
+
+Spec 043 added explicit observation-copy helpers for ML training loops without
+changing the default Gymnasium contract. `NESEnv.step` still returns
+`env.screen`, the zero-copy `(240, 256, 3)` RGB view over the native 32-bit
+screen buffer, and `render` in `rgb_array` mode still returns that same object.
+
+The new opt-in helpers are:
+
+- `env.observation("rgb_array")`: existing zero-copy public screen view.
+- `env.observation("rgb_array_contiguous", output=None)`: C-contiguous RGB
+  `uint8` copy, optionally written into a reusable output array.
+- `env.observation("grayscale", output=None)`: C-contiguous 2-D `uint8` luma
+  copy, optionally written into a reusable output array.
+
+Both copy helpers read directly from the native 32-bit screen buffer in the
+Cython extension. They are intended for training loops that already know they
+need copied observations. They do not choose game-specific crops, resize frames,
+or stack history because those choices depend on the downstream wrapper and
+model. Crop/downsample modes were not kept in this pass to avoid baking a
+game-specific preprocessing policy into generic `nes-py`.
+
+## Benchmark Command
+
+```sh
+.venv/bin/python -m nes_py.speedtest --rom nes_py/tests/games/super-mario-bros-1.nes --observation-profile --steps 1000 --warmup-steps 100 --action-policy noop --json --no-progress
+```
+
+The profile measures complete `step + observation consumption` loops. Each
+operation consumes one byte from the produced observation to keep all paths
+accounted for.
+
+## Local Smoke Results
+
+Single-run profile on macOS, CPython 3.14.2, `super-mario-bros-1.nes`, noop
+actions, 100 warmup steps, 1000 measured steps. Treat these as local direction,
+not a portable threshold.
+
+| Operation | Before `8e33e74` | After | Notes |
+| --- | ---: | ---: | --- |
+| `step` | 1106.94 steps/s | 1440.57 steps/s | Default zero-copy screen view; timing noise dominates this row. |
+| `step_copy` | 1114.20 steps/s | 1117.23 steps/s | Public screen `.copy()` baseline. |
+| `step_contiguous` | 1112.28 steps/s | 1120.66 steps/s | `np.ascontiguousarray(env.screen)` baseline. |
+| `step_python_grayscale` | 1257.46 steps/s | 1261.50 steps/s | NumPy integer luma conversion baseline. |
+| `step_native_rgb_contiguous` | n/a | 1420.08 steps/s | Reused native RGB output buffer. |
+| `step_native_grayscale` | n/a | 1403.44 steps/s | Reused native grayscale output buffer. |
+
+On this machine, native reusable RGB copy was close to step-only and faster
+than the NumPy contiguous-copy baseline. Native reusable grayscale was faster
+than the NumPy grayscale baseline. Users should benchmark their own action
+policy, wrapper stack, crop/resize code, and vectorization strategy before
+assuming the same ranking.

--- a/docs/native-batch-ram-info-reads.md
+++ b/docs/native-batch-ram-info-reads.md
@@ -1,0 +1,68 @@
+# Native Batch RAM Info Reads
+
+Spec 051 adds a generic RAM read descriptor helper for scalar `NESEnv` and
+same-ROM `VectorNESEmulator` workloads. Game wrappers still own address lists,
+reward logic, termination logic, and info dictionaries.
+
+## API Proposal
+
+`env.ram_values(specs, output=None)` returns a C-contiguous uint32 array.
+`VectorNESEmulator.ram_values(specs, output=None)` returns a
+`(num_envs, len(specs))` uint32 array.
+
+Descriptors are intentionally small:
+
+- `address`: read one byte from CPU RAM.
+- `(address, size)`: read a little-endian unsigned integer.
+- `(address, size, encoding)`: read using `byte`, `little`, `big`, `bcd`, or
+  `digits`.
+- `{"address": ..., "size": ..., "encoding": ...}`: mapping form.
+
+The helper validates address ranges, read sizes, encoding names, dtype, output
+shape, contiguity, writability, reset/restore usability, and close behavior.
+The steady-state native path writes directly into caller-provided output when
+one is supplied.
+
+## Profiling
+
+Host: macOS-26.3 arm64, CPython 3.14.2, clang, editable release-extension
+build. ROM: `nes_py/tests/games/super-mario-bros-1.nes`.
+
+Command shape:
+
+```sh
+.venv/bin/python - <<'PY'
+from nes_py.speedtest import run_ram_profile
+for _ in range(5):
+    run_ram_profile(
+        'nes_py/tests/games/super-mario-bros-1.nes',
+        steps=100,
+        warmup_steps=20,
+        seed=111,
+        action_policy='noop',
+    )
+PY
+```
+
+Median throughput:
+
+| Operation | Median steps/s | Min | Max |
+| --- | ---: | ---: | ---: |
+| python_indexing | 354190.37 | 344530.58 | 355923.81 |
+| numpy_take | 1128871.68 | 1103448.02 | 1170740.61 |
+| native_batch | 169599.31 | 166067.17 | 170624.01 |
+| step_python_indexing | 1499.89 | 1405.36 | 1506.29 |
+| step_native_batch | 1484.41 | 1479.67 | 1499.47 |
+
+The native helper is not an isolated RAM-read speedup on this machine. The
+Python-to-native call and descriptor generality are more expensive than plain
+NumPy gather for tiny address sets. In full `step + info` style loops the
+result was within roughly 1% of Python indexing.
+
+## Decision
+
+The implementation is kept as a shared primitive, not as a proven speedup. It
+centralizes validation, supports reusable outputs, gives vector workloads one
+generic RAM readback path, and showed no meaningful regression in frame-heavy
+representative loops. Wrappers should still profile their own address sets
+before replacing direct `env.ram[...]` indexing.

--- a/docs/vector-native-emulator.md
+++ b/docs/vector-native-emulator.md
@@ -1,0 +1,102 @@
+# Native Vector Emulator Prototype
+
+Spec 050 adds an opt-in `VectorNESEmulator` in `nes_py.vector_env` backed by a
+Cython `NativeVectorEmulator`. The class owns multiple `NES::Emulator`
+instances for one ROM and keeps game-specific reward, termination, and info
+logic outside `nes-py`.
+
+## Ownership and Lifetime
+
+- `NativeVectorEmulator` allocates one current-branch `NES::Emulator` per
+  vector slot and deletes those instances when the Python owner is deallocated.
+- `close()` marks native operations closed but does not immediately invalidate
+  outstanding NumPy screen or RAM views. This matches `NativeEmulator` scalar
+  close behavior.
+- `screens` and `rams` are tuples of per-slot zero-copy views. Batch
+  observations use explicit copy helpers because independently allocated
+  emulators cannot expose one contiguous zero-copy 4-D view.
+- `reset()`, `reset_one(index)`, `step(actions)`, and `step_one(index, action)`
+  reuse the scalar emulator reset and frame paths, including instruction
+  batching, mapper hooks, PPU caches, mapper direct-read pages, backup/restore,
+  and native observation helpers.
+- `dump_state(index)` and `load_state(index, snapshot)` use the opaque snapshot
+  API documented in `docs/explicit-state-snapshot-api.md`.
+
+## Worker Strategy
+
+This prototype intentionally does not create persistent worker threads. It
+validates and writes the uint8 action array once, then releases the GIL while a
+native loop steps each emulator serially. The choice keeps teardown simple,
+avoids oversubscription, avoids idle CPU spin, and provides a stable baseline
+for later threaded work. Synchronization wait time and per-worker stats are
+therefore reported as zero or empty.
+
+CPU affinity is not applied by runtime code. The benchmark CLI records
+`--cpu-affinity none` or `round_robin` as an explicit experiment label so later
+threaded prototypes can compare policies without changing production behavior.
+
+## Observation Modes
+
+- `rgb_array`: returns the tuple of existing zero-copy per-env screen views.
+- `rgb_array_contiguous`: copies all slots into a reusable
+  `(num_envs, 240, 256, 3)` uint8 output.
+- `grayscale`: copies all slots into a reusable `(num_envs, 240, 256)` uint8
+  output.
+- `ram_info`: benchmark profile mode that calls the generic batch RAM helper.
+
+## Benchmark Summary
+
+Host: macOS-26.3 arm64, CPython 3.14.2, clang, editable release-extension
+build. ROM: `nes_py/tests/games/super-mario-bros-1.nes`. Command shape:
+
+```sh
+.venv/bin/python - <<'PY'
+from nes_py.speedtest import run_vector_profile
+run_vector_profile(
+    'nes_py/tests/games/super-mario-bros-1.nes',
+    steps=20,
+    warmup_steps=5,
+    seed=101,
+    action_policy='noop',
+    env_counts=(1, 2, 4, 8, 16),
+    observation_modes=('step_only', 'native_rgb_contiguous',
+                       'native_grayscale', 'ram_info'),
+    backends=('scalar_loop', 'native_vector'),
+    runs=5,
+    instrumentation=True,
+)
+PY
+```
+
+Representative medians in total frames/second:
+
+| Mode | Envs | Scalar | Native vector | Change |
+| --- | ---: | ---: | ---: | ---: |
+| step_only | 1 | 2397.20 | 2378.76 | -0.77% |
+| step_only | 4 | 2395.89 | 2394.34 | -0.06% |
+| step_only | 16 | 2400.09 | 2404.63 | +0.19% |
+| rgb_contiguous | 4 | 2350.73 | 2352.04 | +0.06% |
+| grayscale | 4 | 2300.54 | 2309.21 | +0.38% |
+| ram_info | 4 | 2333.00 | 2388.23 | +2.37% |
+| ram_info | 16 | 2364.51 | 2400.39 | +1.52% |
+
+Gymnasium baseline check, step-only profile, same host and ROM:
+
+| Envs | Scalar | SyncVectorEnv | Native vector |
+| ---: | ---: | ---: | ---: |
+| 1 | 2381.06 | 1606.93 | 2377.50 |
+| 4 | 2397.04 | 1625.72 | 2396.60 |
+| 16 | 2400.13 | 1632.19 | 2331.12 |
+
+`AsyncVectorEnv` works from the CLI entry point, but the compact in-process
+summary script was run from stdin and Python multiprocessing could not reload
+`<stdin>` as `__main__`, so those rows were omitted from the table.
+
+## Decision
+
+The serial native vector prototype did not meet the throughput rule for a
+performance acceptance: no 10% median win appeared at 4+ envs and no 15% win
+appeared at the highest count. It is kept because it provides a simpler
+same-ROM native API, shared batch observation and RAM plumbing, clear timing
+instrumentation, no meaningful representative regression, and a safe baseline
+for future threaded experiments.

--- a/docs/vector-throughput-instrumentation.md
+++ b/docs/vector-throughput-instrumentation.md
@@ -1,0 +1,74 @@
+# Vector Throughput Instrumentation
+
+Spec 052 extends `nes_py.speedtest` with repeated vector-oriented throughput
+profiles instead of creating an unrelated script.
+
+## What It Reports
+
+`run_vector_profile` and `python -m nes_py.speedtest --vector-profile` can emit
+structured rows with:
+
+- host metadata, compiler, platform, ROM, action policy, warmup steps,
+  measured steps, env count, backend, and observation/profile mode;
+- total frames/second with repeated rows suitable for median and spread
+  summaries;
+- setup and teardown seconds;
+- action transfer, native step, synchronization wait, observation access,
+  RAM/info readback, and remaining Python overhead seconds;
+- per-worker stats, currently an empty tuple because the kept prototype has no
+  worker threads;
+- instrumentation enabled/disabled and CPU affinity experiment labels.
+
+Backends are `scalar_loop`, `gym_sync_vector_env`, `gym_async_vector_env`, and
+`native_vector`. Observation/profile modes are `step_only`,
+`native_rgb_contiguous`, `native_grayscale`, and `ram_info`. Gymnasium baselines
+skip `ram_info` because generic wrapper-owned RAM reads are not available
+through `AsyncVectorEnv` workers.
+
+## CPU Usage and Affinity
+
+The kept native vector prototype is serial. It does not busy-wait, does not pin
+threads, and does not create worker threads. CPU usage therefore tracks the
+single-thread scalar emulator path plus benchmark-side Python work.
+
+`--cpu-affinity round_robin` is accepted as an explicit experiment label, but
+no production affinity is applied. Future threaded prototypes can use this
+field to compare pinning without silently changing runtime behavior.
+
+## Instrumentation Overhead
+
+Host: macOS-26.3 arm64, CPython 3.14.2, clang, editable release-extension
+build. ROM: `nes_py/tests/games/super-mario-bros-1.nes`. Native vector,
+4 envs, step-only, noop policy, 30 measured steps, 5 warmups, 5 runs:
+
+| Instrumentation | Median frames/s | Min | Max |
+| --- | ---: | ---: | ---: |
+| disabled | 2281.40 | 2278.43 | 2285.35 |
+| enabled | 2274.39 | 2265.42 | 2279.62 |
+
+The measured overhead was -0.31% median throughput, inside the 1% disabled
+overhead budget for this benchmark.
+
+## Example CLI
+
+```sh
+.venv/bin/python -m nes_py.speedtest \
+  --rom nes_py/tests/games/super-mario-bros-1.nes \
+  --vector-profile \
+  --steps 1000 \
+  --warmup-steps 100 \
+  --runs 5 \
+  --env-counts 1,2,4,8,16 \
+  --vector-backend scalar_loop \
+  --vector-backend gym_sync_vector_env \
+  --vector-backend native_vector \
+  --vector-observation step_only \
+  --vector-observation native_rgb_contiguous \
+  --vector-observation native_grayscale \
+  --vector-observation ram_info \
+  --instrumentation \
+  --json \
+  --no-progress
+```
+
+No generated benchmark artifacts are required or committed.

--- a/nes_emu/benchmark/nes_emu/benchmark_ppu_profiles.cpp
+++ b/nes_emu/benchmark/nes_emu/benchmark_ppu_profiles.cpp
@@ -24,6 +24,7 @@ namespace {
 const int CPU_CYCLES_PER_FRAME = 29781;
 const int PPU_CYCLES_PER_FRAME = CPU_CYCLES_PER_FRAME * 3;
 const int CHR_STRESS_READS = 8192;
+const int PRG_STRESS_READS = 8192;
 
 volatile std::uint64_t benchmark_ppu_sink = 0;
 
@@ -51,6 +52,32 @@ void write_fme7_command(
 ) {
     mapper.writePRG(0x8000, command);
     mapper.writePRG(0xa000, value);
+}
+
+void write_mmc1_register(
+    NES::Mapper& mapper,
+    NES::NES_Address address,
+    NES::NES_Byte value
+) {
+    for (int bit = 0; bit < 5; ++bit) {
+        mapper.writePRG(
+            address,
+            static_cast<NES::NES_Byte>((value >> bit) & 0x01)
+        );
+    }
+}
+
+void configure_sxrom_prg_profile(NES::Mapper& mapper) {
+    write_mmc1_register(mapper, 0x8000, 0x0c);
+    write_mmc1_register(mapper, 0xe000, 0x02);
+}
+
+void configure_uxrom_prg_profile(NES::Mapper& mapper) {
+    mapper.writePRG(0x8000, 0x02);
+}
+
+void configure_cnrom_chr_profile(NES::Mapper& mapper) {
+    mapper.writePRG(0x8000, 0x02);
 }
 
 void configure_mmc3_chr_profile(NES::Mapper& mapper) {
@@ -233,6 +260,43 @@ class MapperCHRReadHarness {
     }
 };
 
+class MapperPRGReadHarness {
+ private:
+    NESTest::TemporaryROM rom;
+    NES::Cartridge cartridge;
+    std::unique_ptr<NES::Mapper> mapper;
+    NES::MainBus bus;
+
+ public:
+    MapperPRGReadHarness(
+        const std::string& name,
+        std::uint16_t mapper_id,
+        std::size_t prg_banks,
+        std::size_t chr_banks,
+        MapperSetup setup = nullptr
+    ) :
+        rom(name, mapper_id, prg_banks, chr_banks),
+        cartridge(rom.load()),
+        mapper(NES::MapperFactory(&cartridge)),
+        bus() {
+        REQUIRE(mapper != nullptr);
+        if (setup != nullptr)
+            setup(*mapper);
+        bus.set_mapper(mapper.get());
+    }
+
+    void run_reads() {
+        NES::NES_Byte value = 0;
+        for (int index = 0; index < PRG_STRESS_READS; ++index) {
+            NES::NES_Address address = static_cast<NES::NES_Address>(
+                0x8000 | ((index * 67) & 0x7fff)
+            );
+            value ^= bus.read(address);
+        }
+        benchmark_ppu_sink ^= value;
+    }
+};
+
 class ROMFrameHarness {
  private:
     std::string path;
@@ -290,7 +354,48 @@ MapperCHRReadHarness& mapper_2_chr_harness() {
 }
 
 MapperCHRReadHarness& mapper_3_chr_harness() {
-    static MapperCHRReadHarness harness("benchmark_mapper_003_cnrom", 3, 2, 4);
+    static MapperCHRReadHarness harness(
+        "benchmark_mapper_003_cnrom",
+        3,
+        2,
+        4,
+        false,
+        false,
+        false,
+        configure_cnrom_chr_profile
+    );
+    return harness;
+}
+
+MapperPRGReadHarness& mapper_0_prg_harness() {
+    static MapperPRGReadHarness harness("benchmark_prg_mapper_000_nrom", 0, 2, 1);
+    return harness;
+}
+
+MapperPRGReadHarness& mapper_1_prg_harness() {
+    static MapperPRGReadHarness harness(
+        "benchmark_prg_mapper_001_sxrom",
+        1,
+        4,
+        1,
+        configure_sxrom_prg_profile
+    );
+    return harness;
+}
+
+MapperPRGReadHarness& mapper_2_prg_harness() {
+    static MapperPRGReadHarness harness(
+        "benchmark_prg_mapper_002_uxrom",
+        2,
+        4,
+        0,
+        configure_uxrom_prg_profile
+    );
+    return harness;
+}
+
+MapperPRGReadHarness& mapper_3_prg_harness() {
+    static MapperPRGReadHarness harness("benchmark_prg_mapper_003_cnrom", 3, 2, 4);
     return harness;
 }
 
@@ -514,6 +619,32 @@ TEST_CASE("native mapper CHR read benchmark profiles", "[benchmark][ppu]") {
         "operation=8192-picture-bus-reads"
     ) {
         mapper_69_chr_harness().run_reads();
+    };
+}
+
+TEST_CASE("native mapper PRG read benchmark profiles", "[benchmark][mapper]") {
+    BENCHMARK(
+        "cpu mapper=0 rom=synthetic-nrom operation=8192-main-bus-prg-reads"
+    ) {
+        mapper_0_prg_harness().run_reads();
+    };
+
+    BENCHMARK(
+        "cpu mapper=1 rom=synthetic-sxrom operation=8192-main-bus-prg-reads"
+    ) {
+        mapper_1_prg_harness().run_reads();
+    };
+
+    BENCHMARK(
+        "cpu mapper=2 rom=synthetic-uxrom operation=8192-main-bus-prg-reads"
+    ) {
+        mapper_2_prg_harness().run_reads();
+    };
+
+    BENCHMARK(
+        "cpu mapper=3 rom=synthetic-cnrom operation=8192-main-bus-prg-reads"
+    ) {
+        mapper_3_prg_harness().run_reads();
     };
 }
 

--- a/nes_emu/benchmark/nes_emu/benchmark_ppu_profiles.cpp
+++ b/nes_emu/benchmark/nes_emu/benchmark_ppu_profiles.cpp
@@ -16,6 +16,7 @@
 #include "nes_emu/mapper_factory.hpp"
 #include "nes_emu/picture_bus.hpp"
 #include "nes_emu/ppu.hpp"
+#include "nes_emu/test/nes_emu/support/emulator_inspector.hpp"
 #include "nes_emu/test/nes_emu/support/synthetic_rom.hpp"
 #include "nes_emu/test/nes_emu/support/test_mappers.hpp"
 
@@ -29,6 +30,12 @@ const int PRG_STRESS_READS = 8192;
 volatile std::uint64_t benchmark_ppu_sink = 0;
 
 typedef void (*MapperSetup)(NES::Mapper&);
+
+enum FrameStepMode {
+    DEFAULT_STEP,
+    CYCLE_BY_CYCLE_STEP,
+    INSTRUCTION_BATCHED_STEP,
+};
 
 bool file_exists(const std::string& path) {
     std::ifstream stream(path.c_str(), std::ios::binary);
@@ -301,25 +308,72 @@ class ROMFrameHarness {
  private:
     std::string path;
     int expected_mapper;
+    FrameStepMode mode;
     std::unique_ptr<NES::Emulator> emulator;
 
  public:
-    ROMFrameHarness(const std::string& path, int expected_mapper) :
+    ROMFrameHarness(
+        const std::string& path,
+        int expected_mapper,
+        FrameStepMode mode = DEFAULT_STEP
+    ) :
         path(path),
         expected_mapper(expected_mapper),
+        mode(mode),
         emulator() {
         REQUIRE(file_exists(path));
         emulator.reset(new NES::Emulator(path));
         REQUIRE(emulator->get_mapper_number() == expected_mapper);
         emulator->reset();
         emulator->backup();
+        if (mode == INSTRUCTION_BATCHED_STEP)
+            REQUIRE(NES::EmulatorInspector::uses_instruction_batching(*emulator));
     }
 
     void run_frame() {
         emulator->restore();
-        emulator->step();
+        switch (mode) {
+            case DEFAULT_STEP:
+                emulator->step();
+                break;
+            case CYCLE_BY_CYCLE_STEP:
+                NES::EmulatorInspector::step_cycle_by_cycle(*emulator);
+                break;
+            case INSTRUCTION_BATCHED_STEP:
+                NES::EmulatorInspector::step_instruction_batched(*emulator);
+                break;
+        }
         consume_screen(emulator->get_screen_buffer());
         benchmark_ppu_sink ^= static_cast<std::uint64_t>(expected_mapper);
+    }
+};
+
+class SyntheticROMFrameHarness {
+ private:
+    NESTest::TemporaryROM rom;
+    ROMFrameHarness harness;
+
+ public:
+    explicit SyntheticROMFrameHarness(FrameStepMode mode) :
+        rom(
+            "benchmark_render_off_frame",
+            0,
+            1,
+            1,
+            "horizontal",
+            false,
+            false,
+            false,
+            {
+                0xa9, 0x00,       // LDA #$00
+                0x8d, 0x01, 0x20, // STA PPUMASK
+                0x4c, 0x05, 0x80  // JMP $8005
+            }
+        ),
+        harness(rom.filename(), 0, mode) { }
+
+    void run_frame() {
+        harness.run_frame();
     }
 };
 
@@ -335,6 +389,16 @@ SyntheticPPUHarness& background_only_harness() {
 
 SyntheticPPUHarness& sprite_heavy_harness() {
     static SyntheticPPUHarness harness(0x1e, true);
+    return harness;
+}
+
+SyntheticROMFrameHarness& render_off_cycle_frame_harness() {
+    static SyntheticROMFrameHarness harness(CYCLE_BY_CYCLE_STEP);
+    return harness;
+}
+
+SyntheticROMFrameHarness& render_off_batched_frame_harness() {
+    static SyntheticROMFrameHarness harness(INSTRUCTION_BATCHED_STEP);
     return harness;
 }
 
@@ -468,10 +532,46 @@ ROMFrameHarness& mapper_0_rom_harness() {
     return harness;
 }
 
+ROMFrameHarness& mapper_0_rom_cycle_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/super-mario-bros-1.nes",
+        0,
+        CYCLE_BY_CYCLE_STEP
+    );
+    return harness;
+}
+
+ROMFrameHarness& mapper_0_rom_batched_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/super-mario-bros-1.nes",
+        0,
+        INSTRUCTION_BATCHED_STEP
+    );
+    return harness;
+}
+
 ROMFrameHarness& mapper_1_rom_harness() {
     static ROMFrameHarness harness(
         "nes_py/tests/games/the-legend-of-zelda.nes",
         1
+    );
+    return harness;
+}
+
+ROMFrameHarness& mapper_1_rom_cycle_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/the-legend-of-zelda.nes",
+        1,
+        CYCLE_BY_CYCLE_STEP
+    );
+    return harness;
+}
+
+ROMFrameHarness& mapper_1_rom_batched_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/the-legend-of-zelda.nes",
+        1,
+        INSTRUCTION_BATCHED_STEP
     );
     return harness;
 }
@@ -484,10 +584,46 @@ ROMFrameHarness& mapper_2_rom_harness() {
     return harness;
 }
 
+ROMFrameHarness& mapper_2_rom_cycle_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/mega-man.nes",
+        2,
+        CYCLE_BY_CYCLE_STEP
+    );
+    return harness;
+}
+
+ROMFrameHarness& mapper_2_rom_batched_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/mega-man.nes",
+        2,
+        INSTRUCTION_BATCHED_STEP
+    );
+    return harness;
+}
+
 ROMFrameHarness& mapper_3_rom_harness() {
     static ROMFrameHarness harness(
         "nes_py/tests/games/adventure-island.nes",
         3
+    );
+    return harness;
+}
+
+ROMFrameHarness& mapper_3_rom_cycle_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/adventure-island.nes",
+        3,
+        CYCLE_BY_CYCLE_STEP
+    );
+    return harness;
+}
+
+ROMFrameHarness& mapper_3_rom_batched_harness() {
+    static ROMFrameHarness harness(
+        "nes_py/tests/games/adventure-island.nes",
+        3,
+        INSTRUCTION_BATCHED_STEP
     );
     return harness;
 }
@@ -645,6 +781,81 @@ TEST_CASE("native mapper PRG read benchmark profiles", "[benchmark][mapper]") {
         "cpu mapper=3 rom=synthetic-cnrom operation=8192-main-bus-prg-reads"
     ) {
         mapper_3_prg_harness().run_reads();
+    };
+}
+
+TEST_CASE(
+    "native CPU frame stepping benchmark profiles",
+    "[benchmark][cpu][batching]"
+) {
+    BENCHMARK(
+        "cpu mapper=0 rom=synthetic-render-off render-mode=mask-off "
+        "step-mode=cycle-by-cycle operation=restore-and-step-one-frame"
+    ) {
+        render_off_cycle_frame_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=0 rom=synthetic-render-off render-mode=mask-off "
+        "step-mode=instruction-batched operation=restore-and-step-one-frame"
+    ) {
+        render_off_batched_frame_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=0 rom=super-mario-bros-1 render-mode=full-frame "
+        "step-mode=cycle-by-cycle operation=restore-and-step-one-frame"
+    ) {
+        mapper_0_rom_cycle_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=0 rom=super-mario-bros-1 render-mode=full-frame "
+        "step-mode=instruction-batched operation=restore-and-step-one-frame"
+    ) {
+        mapper_0_rom_batched_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=1 rom=the-legend-of-zelda render-mode=full-frame "
+        "step-mode=cycle-by-cycle operation=restore-and-step-one-frame"
+    ) {
+        mapper_1_rom_cycle_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=1 rom=the-legend-of-zelda render-mode=full-frame "
+        "step-mode=instruction-batched operation=restore-and-step-one-frame"
+    ) {
+        mapper_1_rom_batched_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=2 rom=mega-man render-mode=full-frame "
+        "step-mode=cycle-by-cycle operation=restore-and-step-one-frame"
+    ) {
+        mapper_2_rom_cycle_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=2 rom=mega-man render-mode=full-frame "
+        "step-mode=instruction-batched operation=restore-and-step-one-frame"
+    ) {
+        mapper_2_rom_batched_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=3 rom=adventure-island render-mode=full-frame "
+        "step-mode=cycle-by-cycle operation=restore-and-step-one-frame"
+    ) {
+        mapper_3_rom_cycle_harness().run_frame();
+    };
+
+    BENCHMARK(
+        "cpu mapper=3 rom=adventure-island render-mode=full-frame "
+        "step-mode=instruction-batched operation=restore-and-step-one-frame"
+    ) {
+        mapper_3_rom_batched_harness().run_frame();
     };
 }
 

--- a/nes_emu/include/nes_emu/cpu.hpp
+++ b/nes_emu/include/nes_emu/cpu.hpp
@@ -143,6 +143,18 @@ class CPU {
     void reset(NES_Address start_address);
 
  public:
+    /// Snapshot of CPU state for native determinism tests.
+    struct Snapshot {
+        NES_Address register_PC;
+        NES_Byte register_SP;
+        NES_Byte register_A;
+        NES_Byte register_X;
+        NES_Byte register_Y;
+        NES_Byte flags;
+        int skip_cycles;
+        int cycles;
+    };
+
     /// The interrupt types available to this CPU
     enum InterruptType {
         IRQ_INTERRUPT,
@@ -174,6 +186,40 @@ class CPU {
     /// @param bus the bus to read and write data from / to
     ///
     void cycle(MainBus &bus);
+
+    /// Return true when the next CPU cycle can execute an opcode.
+    inline bool can_execute_instruction() const { return skip_cycles <= 1; }
+
+    /// Execute one instruction and return the CPU cycles it scheduled.
+    ///
+    /// The caller is responsible for advancing PPU and mapper timing for the
+    /// returned cycles. This method runs the opcode on the first cycle and
+    /// leaves skip_cycles ready for the caller to consume the remaining cycles.
+    ///
+    /// @param bus the bus to read and write data from / to
+    /// @return the number of CPU cycles consumed by the instruction
+    ///
+    int execute_instruction(MainBus &bus);
+
+    /// Consume pending instruction/stall cycles without executing an opcode.
+    ///
+    /// @param count the number of CPU cycles already timed externally
+    ///
+    void consume_pending_cycles(int count);
+
+    /// Return a copy of CPU state for native tests.
+    inline Snapshot save_state() const {
+        return {
+            register_PC,
+            register_SP,
+            register_A,
+            register_X,
+            register_Y,
+            flags.byte,
+            skip_cycles,
+            cycles,
+        };
+    }
 
     /// Skip DMA cycles.
     ///

--- a/nes_emu/include/nes_emu/emulator.hpp
+++ b/nes_emu/include/nes_emu/emulator.hpp
@@ -64,6 +64,20 @@ class Emulator {
     /// Refresh picture-bus mirroring if the mapper changed it.
     void synchronize_mapper_mirroring();
 
+    /// Advance PPU and mapper timing for one CPU cycle.
+    void advance_ppu_timing_cycle();
+
+    /// Perform a frame using the original CPU-cycle-by-cycle path.
+    void step_cycle_by_cycle();
+
+    /// Perform a frame using instruction-level CPU batching.
+    void step_instruction_batched();
+
+    /// Return true when the active mapper permits instruction batching.
+    inline bool can_batch_cpu_instructions() const {
+        return !mapper_observes_cpu_cycles;
+    }
+
  public:
     /// The width of the NES screen in pixels
     static const int WIDTH = SCANLINE_VISIBLE_DOTS;

--- a/nes_emu/include/nes_emu/emulator.hpp
+++ b/nes_emu/include/nes_emu/emulator.hpp
@@ -79,6 +79,23 @@ class Emulator {
     }
 
  public:
+    /// Opaque emulator state used by public snapshot bindings and vector
+    /// reset plumbing. The mapper is cloned so callback wiring can be rebuilt
+    /// on load instead of preserving stale function objects.
+    struct Snapshot {
+        MainBus::State bus;
+        PictureBus::State picture_bus;
+        CPU cpu;
+        PPU::Snapshot ppu;
+        std::unique_ptr<Mapper> mapper;
+
+        Snapshot();
+        Snapshot(const Snapshot& other);
+        Snapshot& operator=(const Snapshot& other);
+        Snapshot(Snapshot&& other) noexcept = default;
+        Snapshot& operator=(Snapshot&& other) noexcept = default;
+    };
+
     /// The width of the NES screen in pixels
     static const int WIDTH = SCANLINE_VISIBLE_DOTS;
     /// The height of the NES screen in pixels
@@ -122,6 +139,18 @@ class Emulator {
 
     /// Restore the backup state on the emulator.
     void restore();
+
+    /// Return an opaque, owned snapshot of mutable emulator state.
+    Snapshot save_state() const;
+
+    /// Allocate a heap-owned snapshot for language bindings.
+    Snapshot* create_snapshot() const;
+
+    /// Restore mutable emulator state from an owned snapshot.
+    void load_state(const Snapshot& snapshot);
+
+    /// Restore mutable emulator state from a heap snapshot pointer.
+    void load_snapshot(const Snapshot* snapshot);
 
     /// Return the loaded cartridge mapper number.
     inline int get_mapper_number() { return cartridge.getMapper(); }

--- a/nes_emu/include/nes_emu/main_bus.hpp
+++ b/nes_emu/include/nes_emu/main_bus.hpp
@@ -50,6 +50,10 @@ class MainBus {
     static const std::size_t PPU_REGISTER_COUNT = 8;
     /// Number of callback-capable I/O registers from $4014 through $4017.
     static const std::size_t IO_REGISTER_COUNT = 4;
+    /// Number of direct PRG-ROM read pages mapped at $8000-$ffff.
+    static const std::size_t DIRECT_PRG_READ_PAGE_COUNT = 4;
+    /// Byte size of each direct PRG-ROM read page.
+    static const std::size_t DIRECT_PRG_READ_PAGE_SIZE = 0x2000;
     /// The RAM on the main bus
     std::array<NES_Byte, RAM_SIZE> ram;
     /// a pointer to the mapper on the cartridge
@@ -70,6 +74,11 @@ class MainBus {
     std::array<WriteCallback, IO_REGISTER_COUNT> io_write_callbacks;
     /// Direct callback slots for $4014-$4017 register reads.
     std::array<ReadCallback, IO_REGISTER_COUNT> io_read_callbacks;
+    /// Direct PRG-ROM page pointers for mapper CPU read hot paths.
+    std::array<const NES_Byte*, DIRECT_PRG_READ_PAGE_COUNT> direct_prg_read_pages;
+
+    /// Refresh direct PRG-ROM read pages from the active mapper.
+    void refresh_direct_prg_read_pages();
 
  public:
     /// Mutable main-bus state captured by backup/restore.
@@ -84,7 +93,8 @@ class MainBus {
         cpu(nullptr),
         ppu(nullptr),
         picture_bus(nullptr),
-        controllers(nullptr) { }
+        controllers(nullptr),
+        direct_prg_read_pages{{nullptr, nullptr, nullptr, nullptr}} { }
 
     /// Return a 8-bit pointer to the RAM buffer's first address.
     ///
@@ -111,7 +121,10 @@ class MainBus {
     ///
     /// @param mapper the new mapper pointer for the bus to use
     ///
-    inline void set_mapper(Mapper* mapper) { this->mapper = mapper; }
+    inline void set_mapper(Mapper* mapper) {
+        this->mapper = mapper;
+        refresh_direct_prg_read_pages();
+    }
 
     /// Connect native device pointers for direct hot-path register dispatch.
     inline void connect_devices(

--- a/nes_emu/include/nes_emu/mapper.hpp
+++ b/nes_emu/include/nes_emu/mapper.hpp
@@ -177,6 +177,22 @@ class Mapper {
         return nullptr;
     }
 
+    /// Return a direct PRG-ROM read page for CPU reads, or null if unsafe.
+    inline virtual const NES_Byte* getDirectPRGReadPage(
+        NES_Address page_base
+    ) {
+        (void) page_base;
+        return nullptr;
+    }
+
+    /// Return a direct CHR read page for PPU reads, or null if unsafe.
+    inline virtual const NES_Byte* getDirectCHRReadPage(
+        NES_Address page_base
+    ) {
+        (void) page_base;
+        return nullptr;
+    }
+
     /// Read a byte from the PRG RAM.
     ///
     /// @param address the 16-bit address of the byte to read

--- a/nes_emu/include/nes_emu/mapper.hpp
+++ b/nes_emu/include/nes_emu/mapper.hpp
@@ -237,6 +237,10 @@ class Mapper {
     /// Return true when this mapper needs PPU write callbacks.
     inline virtual bool observesPPUWrites() const { return false; }
 
+    /// Return true when sprite pattern rows may be prefetched one scanline
+    /// ahead without changing mapper-visible CHR behavior.
+    inline virtual bool allowsSpriteRowPrefetch() const { return false; }
+
     /// Return true when this mapper may own or remap nametable data.
     inline virtual bool hasNameTableMapping() const { return false; }
 

--- a/nes_emu/include/nes_emu/mapper.hpp
+++ b/nes_emu/include/nes_emu/mapper.hpp
@@ -193,6 +193,26 @@ class Mapper {
         return nullptr;
     }
 
+    /// Return true when a PRG-space write invalidates direct PRG read pages.
+    inline virtual bool invalidatesDirectPRGReadPagesOnWrite(
+        NES_Address address,
+        NES_Byte value
+    ) const {
+        (void) address;
+        (void) value;
+        return true;
+    }
+
+    /// Return true when a PRG-space write invalidates direct CHR read pages.
+    inline virtual bool invalidatesDirectCHRReadPagesOnWrite(
+        NES_Address address,
+        NES_Byte value
+    ) const {
+        (void) address;
+        (void) value;
+        return true;
+    }
+
     /// Read a byte from the PRG RAM.
     ///
     /// @param address the 16-bit address of the byte to read
@@ -234,6 +254,19 @@ class Mapper {
 
     /// Return true when this mapper needs PPU address callbacks.
     inline virtual bool observesPPUAddresses() const { return false; }
+
+    /// Return true when direct CHR page reads remain safe with PPU address
+    /// observations enabled.
+    inline virtual bool allowsDirectCHRReadWithPPUAddressObservations() const {
+        return false;
+    }
+
+    /// Return true when decoded background tile rows can be cached while
+    /// PPU address observations remain enabled.
+    inline virtual bool allowsBackgroundTileCacheWithPPUAddressObservations()
+        const {
+        return false;
+    }
 
     /// Observe a PPU read after data is resolved.
     inline virtual void onPPURead(NES_Address address, NES_Byte value) {

--- a/nes_emu/include/nes_emu/mapper_bank.hpp
+++ b/nes_emu/include/nes_emu/mapper_bank.hpp
@@ -172,6 +172,26 @@ class BankWindow {
             return 0;
         return memory[offset(address, window_base) % memory.size()];
     }
+
+    /// Return a direct pointer into this window when a contiguous read fits.
+    inline const NES_Byte* readPointer(
+        const std::vector<NES_Byte>& memory,
+        NES_Address address,
+        NES_Address window_base,
+        std::size_t contiguous_size
+    ) const {
+        if (memory.empty())
+            return nullptr;
+        const std::size_t window_offset = (address - window_base) % mapped_size;
+        const std::size_t memory_offset = base_offset + window_offset;
+        if (
+            window_offset + contiguous_size > mapped_size ||
+            memory_offset + contiguous_size > memory.size()
+        ) {
+            return nullptr;
+        }
+        return &memory[memory_offset];
+    }
 };
 
 /// Mapper-owned CHR RAM with explicit ROM/RAM behavior.
@@ -210,6 +230,19 @@ class CHRMemory {
     inline void write(NES_Address address, NES_Byte value) {
         if (!ram.empty())
             ram[address % ram.size()] = value;
+    }
+
+    /// Return a direct pointer into CHR RAM when a contiguous read fits.
+    inline const NES_Byte* readPointer(
+        NES_Address address,
+        std::size_t contiguous_size
+    ) const {
+        if (ram.empty())
+            return nullptr;
+        const std::size_t offset = address % ram.size();
+        if (offset + contiguous_size > ram.size())
+            return nullptr;
+        return &ram[offset];
     }
 };
 

--- a/nes_emu/include/nes_emu/mappers/mapper_CNROM.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_CNROM.hpp
@@ -51,6 +51,24 @@ class MapperCNROM : public Mapper {
         return second_prg.read(cartridge->getROM(), address, 0xc000);
     }
 
+    /// Return a direct 8 KiB PRG read page for CPU hot paths.
+    inline const NES_Byte* getDirectPRGReadPage(NES_Address page_base) {
+        if (page_base < 0xc000) {
+            return first_prg.readPointer(
+                cartridge->getROM(),
+                page_base,
+                0x8000,
+                0x2000
+            );
+        }
+        return second_prg.readPointer(
+            cartridge->getROM(),
+            page_base,
+            0xc000,
+            0x2000
+        );
+    }
+
     /// Write a byte to an address in the PRG RAM.
     ///
     /// @param address the 16-bit address to write to
@@ -70,6 +88,16 @@ class MapperCNROM : public Mapper {
     ///
     inline NES_Byte readCHR(NES_Address address) {
         return selected_chr.read(cartridge->getVROM(), address, 0x0000);
+    }
+
+    /// Return a direct 1 KiB CHR read page for PPU hot paths.
+    inline const NES_Byte* getDirectCHRReadPage(NES_Address page_base) {
+        return selected_chr.readPointer(
+            cartridge->getVROM(),
+            page_base,
+            0x0000,
+            0x0400
+        );
     }
 
     /// Write a byte to an address in the CHR RAM.

--- a/nes_emu/include/nes_emu/mappers/mapper_MMC3.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_MMC3.hpp
@@ -78,6 +78,9 @@ class MapperMMC3 : public Mapper {
     /// Read a byte from the CHR ROM/RAM.
     NES_Byte readCHR(NES_Address address);
 
+    /// Return a direct 1 KiB CHR read page for PPU hot paths.
+    const NES_Byte* getDirectCHRReadPage(NES_Address page_base);
+
     /// Write a byte to CHR RAM when present.
     void writeCHR(NES_Address address, NES_Byte value);
 
@@ -95,6 +98,28 @@ class MapperMMC3 : public Mapper {
 
     /// Return true because MMC3 IRQs are clocked by PPU A12 edges.
     inline bool observesPPUAddresses() const { return true; }
+
+    /// MMC3 A12 edge observation is compatible with direct CHR reads.
+    inline bool allowsDirectCHRReadWithPPUAddressObservations() const {
+        return true;
+    }
+
+    /// MMC3 observes PPU addresses during tile-row fetches, not readCHR().
+    inline bool allowsBackgroundTileCacheWithPPUAddressObservations() const {
+        return true;
+    }
+
+    /// Return true when a PRG-space write changes direct PRG read pages.
+    bool invalidatesDirectPRGReadPagesOnWrite(
+        NES_Address address,
+        NES_Byte value
+    ) const;
+
+    /// Return true when a PRG-space write changes direct CHR read pages.
+    bool invalidatesDirectCHRReadPagesOnWrite(
+        NES_Address address,
+        NES_Byte value
+    ) const;
 };
 
 }  // namespace NES

--- a/nes_emu/include/nes_emu/mappers/mapper_NROM.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_NROM.hpp
@@ -48,6 +48,24 @@ class MapperNROM : public Mapper {
         return second_prg.read(cartridge->getROM(), address, 0xc000);
     }
 
+    /// Return a direct 8 KiB PRG read page for CPU hot paths.
+    inline const NES_Byte* getDirectPRGReadPage(NES_Address page_base) {
+        if (page_base < 0xc000) {
+            return first_prg.readPointer(
+                cartridge->getROM(),
+                page_base,
+                0x8000,
+                0x2000
+            );
+        }
+        return second_prg.readPointer(
+            cartridge->getROM(),
+            page_base,
+            0xc000,
+            0x2000
+        );
+    }
+
     /// Write a byte to an address in the PRG RAM.
     ///
     /// @param address the 16-bit address to write to
@@ -64,6 +82,18 @@ class MapperNROM : public Mapper {
         if (chr_memory.usesRAM())
             return chr_memory.read(address);
         return chr_rom.read(cartridge->getVROM(), address, 0x0000);
+    }
+
+    /// Return a direct 1 KiB CHR read page for PPU hot paths.
+    inline const NES_Byte* getDirectCHRReadPage(NES_Address page_base) {
+        if (chr_memory.usesRAM())
+            return chr_memory.readPointer(page_base, 0x0400);
+        return chr_rom.readPointer(
+            cartridge->getVROM(),
+            page_base,
+            0x0000,
+            0x0400
+        );
     }
 
     /// Write a byte to an address in the CHR RAM.

--- a/nes_emu/include/nes_emu/mappers/mapper_NROM.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_NROM.hpp
@@ -72,6 +72,9 @@ class MapperNROM : public Mapper {
     /// @param value the byte to write to the given address
     ///
     void writeCHR(NES_Address address, NES_Byte value);
+
+    /// NROM has a stable CHR window; CHR-RAM writes are tracked by PictureBus.
+    inline bool allowsSpriteRowPrefetch() const { return true; }
 };
 
 }  // namespace NES

--- a/nes_emu/include/nes_emu/mappers/mapper_SxROM.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_SxROM.hpp
@@ -70,6 +70,9 @@ class MapperSxROM : public Mapper {
         return second_prg.read(cartridge->getROM(), address, 0xc000);
     }
 
+    /// Return a direct 8 KiB PRG read page for CPU hot paths.
+    const NES_Byte* getDirectPRGReadPage(NES_Address page_base);
+
     /// Write a byte to an address in the PRG RAM.
     ///
     /// @param address the 16-bit address to write to
@@ -89,6 +92,9 @@ class MapperSxROM : public Mapper {
             return first_chr.read(cartridge->getVROM(), address, 0x0000);
         return second_chr.read(cartridge->getVROM(), address, 0x1000);
     }
+
+    /// Return a direct 1 KiB CHR read page for PPU hot paths.
+    const NES_Byte* getDirectCHRReadPage(NES_Address page_base);
 
     /// Write a byte to an address in the CHR RAM.
     ///

--- a/nes_emu/include/nes_emu/mappers/mapper_UxROM.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_UxROM.hpp
@@ -44,6 +44,9 @@ class MapperUxROM : public Mapper {
     ///
     NES_Byte readPRG(NES_Address address);
 
+    /// Return a direct 8 KiB PRG read page for CPU hot paths.
+    const NES_Byte* getDirectPRGReadPage(NES_Address page_base);
+
     /// Write a byte to an address in the PRG RAM.
     ///
     /// @param address the 16-bit address to write to
@@ -57,6 +60,9 @@ class MapperUxROM : public Mapper {
     /// @return the byte located at the given address in CHR RAM
     ///
     NES_Byte readCHR(NES_Address address);
+
+    /// Return a direct 1 KiB CHR read page for PPU hot paths.
+    const NES_Byte* getDirectCHRReadPage(NES_Address page_base);
 
     /// Write a byte to an address in the CHR RAM.
     ///

--- a/nes_emu/include/nes_emu/mappers/mapper_UxROM.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_UxROM.hpp
@@ -64,6 +64,9 @@ class MapperUxROM : public Mapper {
     /// @param value the byte to write to the given address
     ///
     void writeCHR(NES_Address address, NES_Byte value);
+
+    /// UxROM only switches PRG banks; CHR-RAM writes are tracked by PictureBus.
+    inline bool allowsSpriteRowPrefetch() const { return true; }
 };
 
 }  // namespace NES

--- a/nes_emu/include/nes_emu/picture_bus.hpp
+++ b/nes_emu/include/nes_emu/picture_bus.hpp
@@ -23,6 +23,10 @@ class PictureBus {
     static const std::size_t NAME_TABLE_RAM_SIZE = 0x1000;
     /// Number of bytes in local palette RAM.
     static const std::size_t PALETTE_RAM_SIZE = 0x20;
+    /// Number of direct CHR read pages mapped at PPU $0000-$1fff.
+    static const std::size_t DIRECT_CHR_READ_PAGE_COUNT = 8;
+    /// Byte size of each direct CHR read page.
+    static const std::size_t DIRECT_CHR_READ_PAGE_SIZE = 0x0400;
     /// the VRAM on the picture bus
     std::array<NES_Byte, NAME_TABLE_RAM_SIZE> ram;
     /// indexes where they start in RAM vector
@@ -37,6 +41,8 @@ class PictureBus {
     bool mapper_observes_ppu_writes;
     bool mapper_has_name_table_mapping;
     bool mapper_allows_sprite_row_prefetch;
+    /// Direct CHR page pointers for mapper PPU read hot paths.
+    std::array<const NES_Byte*, DIRECT_CHR_READ_PAGE_COUNT> direct_chr_read_pages;
     /// Incremented whenever CPU/PPU writes can invalidate cached render data.
     std::uint64_t write_generation;
 
@@ -66,6 +72,10 @@ class PictureBus {
         mapper_observes_ppu_writes(false),
         mapper_has_name_table_mapping(false),
         mapper_allows_sprite_row_prefetch(false),
+        direct_chr_read_pages{{
+            nullptr, nullptr, nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr
+        }},
         write_generation(0) { }
 
     /// Read a byte from an address on the VRAM.
@@ -104,6 +114,7 @@ class PictureBus {
         mapper_allows_sprite_row_prefetch = (
             mapper != nullptr && mapper->allowsSpriteRowPrefetch()
         );
+        refresh_direct_chr_read_pages();
         update_mirroring();
     }
 
@@ -153,6 +164,9 @@ class PictureBus {
 
     /// Update the mirroring and name table from the mapper.
     void update_mirroring();
+
+    /// Refresh direct CHR read pages from the active mapper.
+    void refresh_direct_chr_read_pages();
 };
 
 }  // namespace NES

--- a/nes_emu/include/nes_emu/picture_bus.hpp
+++ b/nes_emu/include/nes_emu/picture_bus.hpp
@@ -36,6 +36,7 @@ class PictureBus {
     bool mapper_observes_ppu_reads;
     bool mapper_observes_ppu_writes;
     bool mapper_has_name_table_mapping;
+    bool mapper_allows_sprite_row_prefetch;
     /// Incremented whenever CPU/PPU writes can invalidate cached render data.
     std::uint64_t write_generation;
 
@@ -64,6 +65,7 @@ class PictureBus {
         mapper_observes_ppu_reads(false),
         mapper_observes_ppu_writes(false),
         mapper_has_name_table_mapping(false),
+        mapper_allows_sprite_row_prefetch(false),
         write_generation(0) { }
 
     /// Read a byte from an address on the VRAM.
@@ -99,6 +101,9 @@ class PictureBus {
         mapper_has_name_table_mapping = (
             mapper != nullptr && mapper->hasNameTableMapping()
         );
+        mapper_allows_sprite_row_prefetch = (
+            mapper != nullptr && mapper->allowsSpriteRowPrefetch()
+        );
         update_mirroring();
     }
 
@@ -118,6 +123,16 @@ class PictureBus {
             mapper_observes_ppu_addresses ||
             mapper_observes_ppu_reads ||
             mapper_observes_ppu_writes
+        );
+    }
+
+    /// Return true when sprite rows can be prefetched without mapper effects.
+    inline bool can_prefetch_sprite_rows() const {
+        return (
+            mapper != nullptr &&
+            mapper_allows_sprite_row_prefetch &&
+            !has_mapper_ppu_observers() &&
+            !mapper_has_name_table_mapping
         );
     }
 

--- a/nes_emu/include/nes_emu/picture_bus.hpp
+++ b/nes_emu/include/nes_emu/picture_bus.hpp
@@ -41,6 +41,7 @@ class PictureBus {
     bool mapper_observes_ppu_writes;
     bool mapper_has_name_table_mapping;
     bool mapper_allows_sprite_row_prefetch;
+    bool mapper_allows_background_tile_cache_with_ppu_address_observations;
     /// Direct CHR page pointers for mapper PPU read hot paths.
     std::array<const NES_Byte*, DIRECT_CHR_READ_PAGE_COUNT> direct_chr_read_pages;
     /// Incremented whenever CPU/PPU writes can invalidate cached render data.
@@ -72,6 +73,7 @@ class PictureBus {
         mapper_observes_ppu_writes(false),
         mapper_has_name_table_mapping(false),
         mapper_allows_sprite_row_prefetch(false),
+        mapper_allows_background_tile_cache_with_ppu_address_observations(false),
         direct_chr_read_pages{{
             nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr
@@ -114,6 +116,10 @@ class PictureBus {
         mapper_allows_sprite_row_prefetch = (
             mapper != nullptr && mapper->allowsSpriteRowPrefetch()
         );
+        mapper_allows_background_tile_cache_with_ppu_address_observations = (
+            mapper != nullptr &&
+            mapper->allowsBackgroundTileCacheWithPPUAddressObservations()
+        );
         refresh_direct_chr_read_pages();
         update_mirroring();
     }
@@ -144,6 +150,20 @@ class PictureBus {
             mapper_allows_sprite_row_prefetch &&
             !has_mapper_ppu_observers() &&
             !mapper_has_name_table_mapping
+        );
+    }
+
+    /// Return true when background tile rows can be cached safely.
+    inline bool can_cache_background_tile_rows() const {
+        return (
+            mapper != nullptr &&
+            !mapper_observes_ppu_reads &&
+            !mapper_observes_ppu_writes &&
+            !mapper_has_name_table_mapping &&
+            (
+                !mapper_observes_ppu_addresses ||
+                mapper_allows_background_tile_cache_with_ppu_address_observations
+            )
         );
     }
 

--- a/nes_emu/include/nes_emu/ppu.hpp
+++ b/nes_emu/include/nes_emu/ppu.hpp
@@ -34,6 +34,8 @@ class PPU {
     static const std::size_t OAM_SIZE = 64 * 4;
     /// Maximum sprites considered on one scanline by NES sprite evaluation.
     static const std::size_t MAX_SCANLINE_SPRITES = 8;
+    /// Minimum sprite pressure needed before row prefetch amortizes its cost.
+    static const std::size_t SPRITE_PREFETCH_MIN_SPRITES = 2;
     /// Number of pixels in the visible screen buffer.
     static const std::size_t SCREEN_PIXEL_COUNT =
         VISIBLE_SCANLINES * SCANLINE_VISIBLE_DOTS;
@@ -45,6 +47,35 @@ class PPU {
     std::array<NES_Byte, MAX_SCANLINE_SPRITES> scanline_sprites;
     /// Number of valid entries in scanline_sprites.
     std::size_t scanline_sprite_count;
+    /// Cached sprite pattern row ready for the current scanline.
+    struct SpriteRow {
+        NES_Byte sprite_index;
+        NES_Byte x;
+        NES_Byte attribute;
+        NES_Byte pattern_low;
+        NES_Byte pattern_high;
+        NES_Byte palette_base;
+        std::array<NES_Byte, 8> pixels;
+        bool foreground;
+        bool valid;
+
+        SpriteRow() :
+            sprite_index(0),
+            x(0),
+            attribute(0),
+            pattern_low(0),
+            pattern_high(0),
+            palette_base(0),
+            pixels(),
+            foreground(false),
+            valid(false) { }
+    };
+    /// Decoded sprite rows selected for the current scanline.
+    std::array<SpriteRow, MAX_SCANLINE_SPRITES> scanline_sprite_rows;
+    /// Whether scanline_sprite_rows can be used for current composition.
+    bool scanline_sprite_rows_cached;
+    /// Picture-bus write generation captured when rows were prefetched.
+    std::uint64_t scanline_sprite_rows_generation;
 
     /// The current pipeline state of the PPU
     enum PipelineState {
@@ -128,12 +159,27 @@ class PPU {
     /// scan lines and width matching the number of visible scan line dots.
     NES_Pixel screen[VISIBLE_SCANLINES][SCANLINE_VISIBLE_DOTS];
 
+    /// Invalidate sprite row prefetch data.
+    void invalidate_sprite_rows();
+
+    /// Return the pattern address for a sprite row after vertical selection.
+    NES_Address sprite_pattern_address(NES_Byte tile, int y_offset) const;
+
+    /// Prefetch rows for sprites selected for the next scanline.
+    void prefetch_scanline_sprite_rows(PictureBus& bus);
+
+    /// Evaluate visible sprites for the next scanline.
+    void evaluate_scanline_sprites(PictureBus& bus);
+
  public:
     /// Mutable PPU state captured by backup/restore.
     struct Snapshot {
         std::array<NES_Byte, OAM_SIZE> sprite_memory;
         std::array<NES_Byte, MAX_SCANLINE_SPRITES> scanline_sprites;
         std::size_t scanline_sprite_count;
+        std::array<SpriteRow, MAX_SCANLINE_SPRITES> scanline_sprite_rows;
+        bool scanline_sprite_rows_cached;
+        std::uint64_t scanline_sprite_rows_generation;
         int pipeline_state;
         int cycles;
         int scanline;
@@ -169,7 +215,10 @@ class PPU {
     PPU() :
         sprite_memory(),
         scanline_sprites(),
+        scanline_sprite_rows(),
         scanline_sprite_count(0),
+        scanline_sprite_rows_cached(false),
+        scanline_sprite_rows_generation(0),
         screen() { }
 
     /// Perform a single cycle on the PPU.
@@ -249,6 +298,7 @@ class PPU {
     ///
     inline void set_OAM_data(NES_Byte value) {
         sprite_memory[sprite_data_address++] = value;
+        invalidate_sprite_rows();
     }
 
     /// Return a pointer to the screen buffer.

--- a/nes_emu/include/nes_emu/ppu.hpp
+++ b/nes_emu/include/nes_emu/ppu.hpp
@@ -154,6 +154,14 @@ class PPU {
     NES_Byte background_tile_cache_high;
     /// Cached attribute byte for the current background tile row.
     NES_Byte background_tile_cache_attribute;
+    /// Cached low bitplane with bits indexed by fine X.
+    NES_Byte background_tile_cache_low_bits;
+    /// Cached high bitplane with bits indexed by fine X.
+    NES_Byte background_tile_cache_high_bits;
+    /// Cached high palette bits for the current attribute quadrant.
+    NES_Byte background_tile_cache_palette_high;
+    /// Cached opacity mask indexed by fine X.
+    NES_Byte background_tile_cache_opaque_mask;
 
     /// The internal screen data structure with height matching the visible
     /// scan lines and width matching the number of visible scan line dots.
@@ -170,6 +178,15 @@ class PPU {
 
     /// Evaluate visible sprites for the next scanline.
     void evaluate_scanline_sprites(PictureBus& bus);
+
+    /// Invalidate decoded background tile-row data.
+    void invalidate_background_tile_cache();
+
+    /// Decode and cache the current background tile row.
+    void fill_background_tile_cache(
+        PictureBus& bus,
+        std::uint64_t generation
+    );
 
  public:
     /// Mutable PPU state captured by backup/restore.
@@ -208,6 +225,10 @@ class PPU {
         NES_Byte background_tile_cache_low;
         NES_Byte background_tile_cache_high;
         NES_Byte background_tile_cache_attribute;
+        NES_Byte background_tile_cache_low_bits;
+        NES_Byte background_tile_cache_high_bits;
+        NES_Byte background_tile_cache_palette_high;
+        NES_Byte background_tile_cache_opaque_mask;
         std::array<NES_Pixel, SCREEN_PIXEL_COUNT> screen;
     };
 
@@ -219,6 +240,10 @@ class PPU {
         scanline_sprite_count(0),
         scanline_sprite_rows_cached(false),
         scanline_sprite_rows_generation(0),
+        background_tile_cache_low_bits(0),
+        background_tile_cache_high_bits(0),
+        background_tile_cache_palette_high(0),
+        background_tile_cache_opaque_mask(0),
         screen() { }
 
     /// Perform a single cycle on the PPU.

--- a/nes_emu/src/nes_emu/cpu.cpp
+++ b/nes_emu/src/nes_emu/cpu.cpp
@@ -622,6 +622,37 @@ bool CPU::execute_opcode(MainBus &bus, NES_Byte opcode) {
     return false;
 }
 
+int CPU::execute_instruction(MainBus &bus) {
+    // Match CPU::cycle's ordering: the CPU cycle is counted before the opcode
+    // performs bus I/O, which keeps OAM DMA odd/even penalties unchanged.
+    ++cycles;
+
+    // This API is normally called only at an instruction boundary. If a caller
+    // reaches it during DMA or interrupt stall time, consume one CPU cycle using
+    // the same skip counter semantics as CPU::cycle.
+    if (skip_cycles-- > 1)
+        return 1;
+
+    skip_cycles = 0;
+    NES_Byte op = bus.read(register_PC++);
+    if (execute_opcode(bus, op))
+        skip_cycles += OPERATION_CYCLES[op];
+    else
+        std::cout << "failed to execute opcode: " << std::hex << +op << std::endl;
+
+    return skip_cycles > 0 ? skip_cycles : 1;
+}
+
+void CPU::consume_pending_cycles(int count) {
+    if (count <= 0)
+        return;
+
+    cycles += count;
+    skip_cycles -= count;
+    if (skip_cycles < 1)
+        skip_cycles = 1;
+}
+
 void CPU::cycle(MainBus &bus) {
     // increment the number of cycles
     ++cycles;

--- a/nes_emu/src/nes_emu/emulator.cpp
+++ b/nes_emu/src/nes_emu/emulator.cpp
@@ -10,8 +10,34 @@
 #include "nes_emu/log.hpp"
 #include <algorithm>
 #include <stdexcept>
+#include <utility>
 
 namespace NES {
+
+Emulator::Snapshot::Snapshot() :
+    bus(),
+    picture_bus(),
+    cpu(),
+    ppu(),
+    mapper(nullptr) { }
+
+Emulator::Snapshot::Snapshot(const Snapshot& other) :
+    bus(other.bus),
+    picture_bus(other.picture_bus),
+    cpu(other.cpu),
+    ppu(other.ppu),
+    mapper(other.mapper == nullptr ? nullptr : other.mapper->clone()) { }
+
+Emulator::Snapshot& Emulator::Snapshot::operator=(const Snapshot& other) {
+    if (this != &other) {
+        bus = other.bus;
+        picture_bus = other.picture_bus;
+        cpu = other.cpu;
+        ppu = other.ppu;
+        mapper = other.mapper == nullptr ? nullptr : other.mapper->clone();
+    }
+    return *this;
+}
 
 Emulator::Emulator(std::string rom_path) :
     mapper_observes_cpu_cycles(false) {
@@ -94,23 +120,61 @@ void Emulator::step() {
 }
 
 void Emulator::backup() {
-    backup_mapper = mapper->clone();
-    backup_bus = bus.save_state();
-    backup_picture_bus = picture_bus.save_state();
-    backup_cpu = cpu;
-    backup_ppu = ppu.save_state();
+    Snapshot snapshot = save_state();
+    backup_mapper = std::move(snapshot.mapper);
+    backup_bus = snapshot.bus;
+    backup_picture_bus = snapshot.picture_bus;
+    backup_cpu = snapshot.cpu;
+    backup_ppu = snapshot.ppu;
 }
 
 void Emulator::restore() {
     if (backup_mapper == nullptr)
         return;
 
-    mapper = backup_mapper->clone();
-    bus.load_state(backup_bus);
-    picture_bus.load_state(backup_picture_bus);
-    cpu = backup_cpu;
-    ppu.load_state(backup_ppu);
+    Snapshot snapshot;
+    snapshot.mapper = backup_mapper->clone();
+    snapshot.bus = backup_bus;
+    snapshot.picture_bus = backup_picture_bus;
+    snapshot.cpu = backup_cpu;
+    snapshot.ppu = backup_ppu;
+    load_state(snapshot);
+}
+
+Emulator::Snapshot Emulator::save_state() const {
+    Snapshot snapshot;
+    if (mapper == nullptr)
+        throw std::runtime_error("cannot snapshot emulator without a mapper");
+    snapshot.mapper = mapper->clone();
+    snapshot.bus = bus.save_state();
+    snapshot.picture_bus = picture_bus.save_state();
+    snapshot.cpu = cpu;
+    snapshot.ppu = ppu.save_state();
+    return snapshot;
+}
+
+Emulator::Snapshot* Emulator::create_snapshot() const {
+    Snapshot snapshot = save_state();
+    return new Snapshot(std::move(snapshot));
+}
+
+void Emulator::load_state(const Snapshot& snapshot) {
+    if (snapshot.mapper == nullptr)
+        throw std::runtime_error("cannot restore an empty emulator snapshot");
+
+    mapper = snapshot.mapper->clone();
+    bus.load_state(snapshot.bus);
+    picture_bus.load_state(snapshot.picture_bus);
+    cpu = snapshot.cpu;
+    ppu.load_state(snapshot.ppu);
     wire_mapper();
+    synchronize_mapper_mirroring();
+}
+
+void Emulator::load_snapshot(const Snapshot* snapshot) {
+    if (snapshot == nullptr)
+        throw std::runtime_error("cannot restore a null emulator snapshot");
+    load_state(*snapshot);
 }
 
 }  // namespace NES

--- a/nes_emu/src/nes_emu/emulator.cpp
+++ b/nes_emu/src/nes_emu/emulator.cpp
@@ -8,6 +8,7 @@
 #include "nes_emu/emulator.hpp"
 #include "nes_emu/mapper_factory.hpp"
 #include "nes_emu/log.hpp"
+#include <algorithm>
 #include <stdexcept>
 
 namespace NES {
@@ -41,18 +42,55 @@ void Emulator::synchronize_mapper_mirroring() {
         picture_bus.update_mirroring();
 }
 
-void Emulator::step() {
-    // render a single frame on the emulator
+void Emulator::advance_ppu_timing_cycle() {
+    // 3 PPU steps per CPU step
+    ppu.cycle(picture_bus);
+    ppu.cycle(picture_bus);
+    ppu.cycle(picture_bus);
+    if (mapper_observes_cpu_cycles)
+        mapper->onCPUCycle();
+}
+
+void Emulator::step_cycle_by_cycle() {
     for (int i = 0; i < CYCLES_PER_FRAME; i++) {
-        // 3 PPU steps per CPU step
-        ppu.cycle(picture_bus);
-        ppu.cycle(picture_bus);
-        ppu.cycle(picture_bus);
-        if (mapper_observes_cpu_cycles)
-            mapper->onCPUCycle();
+        advance_ppu_timing_cycle();
         cpu.cycle(bus);
         synchronize_mapper_mirroring();
     }
+}
+
+void Emulator::step_instruction_batched() {
+    for (int i = 0; i < CYCLES_PER_FRAME; ) {
+        advance_ppu_timing_cycle();
+
+        if (!cpu.can_execute_instruction()) {
+            cpu.cycle(bus);
+            synchronize_mapper_mirroring();
+            ++i;
+            continue;
+        }
+
+        int instruction_cycles = cpu.execute_instruction(bus);
+        synchronize_mapper_mirroring();
+        ++i;
+
+        const int remaining_frame_cycles = CYCLES_PER_FRAME - i;
+        const int batched_cycles = std::min(
+            instruction_cycles - 1,
+            remaining_frame_cycles
+        );
+        for (int cycle = 0; cycle < batched_cycles; ++cycle)
+            advance_ppu_timing_cycle();
+        cpu.consume_pending_cycles(batched_cycles);
+        i += batched_cycles;
+    }
+}
+
+void Emulator::step() {
+    if (can_batch_cpu_instructions())
+        step_instruction_batched();
+    else
+        step_cycle_by_cycle();
 }
 
 void Emulator::backup() {

--- a/nes_emu/src/nes_emu/main_bus.cpp
+++ b/nes_emu/src/nes_emu/main_bus.cpp
@@ -158,10 +158,26 @@ void MainBus::write(NES_Address address, NES_Byte value) {
         if (mapper != nullptr)
             mapper->writePRGRAM(address, value);
     } else {
-        mapper->writePRG(address, mapper->resolveBusConflict(address, value));
-        refresh_direct_prg_read_pages();
-        if (picture_bus != nullptr)
+        const NES_Byte resolved_value =
+            mapper->resolveBusConflict(address, value);
+        mapper->writePRG(address, resolved_value);
+        if (
+            mapper->invalidatesDirectPRGReadPagesOnWrite(
+                address,
+                resolved_value
+            )
+        ) {
+            refresh_direct_prg_read_pages();
+        }
+        if (
+            picture_bus != nullptr &&
+            mapper->invalidatesDirectCHRReadPagesOnWrite(
+                address,
+                resolved_value
+            )
+        ) {
             picture_bus->refresh_direct_chr_read_pages();
+        }
     }
 }
 

--- a/nes_emu/src/nes_emu/main_bus.cpp
+++ b/nes_emu/src/nes_emu/main_bus.cpp
@@ -14,6 +14,19 @@
 
 namespace NES {
 
+void MainBus::refresh_direct_prg_read_pages() {
+    direct_prg_read_pages.fill(nullptr);
+    if (mapper == nullptr)
+        return;
+
+    for (std::size_t page = 0; page < direct_prg_read_pages.size(); ++page) {
+        NES_Address page_base = static_cast<NES_Address>(
+            0x8000 + page * DIRECT_PRG_READ_PAGE_SIZE
+        );
+        direct_prg_read_pages[page] = mapper->getDirectPRGReadPage(page_base);
+    }
+}
+
 NES_Byte MainBus::read(NES_Address address) {
     if (address < 0x2000) {
         return ram[address & 0x7ff];
@@ -66,6 +79,11 @@ NES_Byte MainBus::read(NES_Address address) {
         if (mapper != nullptr)
             return mapper->readPRGRAM(address);
     } else {
+        const NES_Byte* direct_page = direct_prg_read_pages[
+            (address - 0x8000) / DIRECT_PRG_READ_PAGE_SIZE
+        ];
+        if (direct_page != nullptr)
+            return direct_page[address & (DIRECT_PRG_READ_PAGE_SIZE - 1)];
         return mapper->readPRG(address);
     }
     return 0;
@@ -141,6 +159,9 @@ void MainBus::write(NES_Address address, NES_Byte value) {
             mapper->writePRGRAM(address, value);
     } else {
         mapper->writePRG(address, mapper->resolveBusConflict(address, value));
+        refresh_direct_prg_read_pages();
+        if (picture_bus != nullptr)
+            picture_bus->refresh_direct_chr_read_pages();
     }
 }
 

--- a/nes_emu/src/nes_emu/mappers/mapper_MMC3.cpp
+++ b/nes_emu/src/nes_emu/mappers/mapper_MMC3.cpp
@@ -159,6 +159,20 @@ NES_Byte MapperMMC3::readCHR(NES_Address address) {
     return chr_windows[slot].read(cartridge->getVROM(), address, base);
 }
 
+const NES_Byte* MapperMMC3::getDirectCHRReadPage(NES_Address page_base) {
+    if (chr_memory.usesRAM())
+        return chr_memory.readPointer(page_base, CHR_WINDOW_SIZE);
+
+    const std::size_t slot = (page_base & 0x1fff) / CHR_WINDOW_SIZE;
+    const NES_Address base = static_cast<NES_Address>(slot * CHR_WINDOW_SIZE);
+    return chr_windows[slot].readPointer(
+        cartridge->getVROM(),
+        page_base,
+        base,
+        CHR_WINDOW_SIZE
+    );
+}
+
 void MapperMMC3::writeCHR(NES_Address address, NES_Byte value) {
     if (chr_memory.usesRAM())
         chr_memory.write(address, value);
@@ -212,6 +226,30 @@ void MapperMMC3::onPPUAddress(NES_Address address) {
     }
     last_ppu_a12 = true;
     ppu_a12_low_observations = 0;
+}
+
+bool MapperMMC3::invalidatesDirectPRGReadPagesOnWrite(
+    NES_Address address,
+    NES_Byte value
+) const {
+    (void) value;
+    if (address > 0x9fff)
+        return false;
+    if ((address & 0x0001) == 0)
+        return true;
+    return (bank_select & 0x07) >= 6;
+}
+
+bool MapperMMC3::invalidatesDirectCHRReadPagesOnWrite(
+    NES_Address address,
+    NES_Byte value
+) const {
+    (void) value;
+    if (address > 0x9fff)
+        return false;
+    if ((address & 0x0001) == 0)
+        return true;
+    return (bank_select & 0x07) <= 5;
 }
 
 }  // namespace NES

--- a/nes_emu/src/nes_emu/mappers/mapper_SxROM.cpp
+++ b/nes_emu/src/nes_emu/mappers/mapper_SxROM.cpp
@@ -78,6 +78,23 @@ void MapperSxROM::calculatePRGWindows() {
     }
 }
 
+const NES_Byte* MapperSxROM::getDirectPRGReadPage(NES_Address page_base) {
+    if (page_base < 0xc000) {
+        return first_prg.readPointer(
+            cartridge->getROM(),
+            page_base,
+            0x8000,
+            0x2000
+        );
+    }
+    return second_prg.readPointer(
+        cartridge->getROM(),
+        page_base,
+        0xc000,
+        0x2000
+    );
+}
+
 void MapperSxROM::calculateCHRWindows() {
     if (chr_memory.usesRAM())
         return;
@@ -90,6 +107,25 @@ void MapperSxROM::calculateCHRWindows() {
         first_chr.selectBank(vrom_size, 0x1000, register_chr0);
         second_chr.selectBank(vrom_size, 0x1000, register_chr1);
     }
+}
+
+const NES_Byte* MapperSxROM::getDirectCHRReadPage(NES_Address page_base) {
+    if (chr_memory.usesRAM())
+        return chr_memory.readPointer(page_base, 0x0400);
+    if (page_base < 0x1000) {
+        return first_chr.readPointer(
+            cartridge->getVROM(),
+            page_base,
+            0x0000,
+            0x0400
+        );
+    }
+    return second_chr.readPointer(
+        cartridge->getVROM(),
+        page_base,
+        0x1000,
+        0x0400
+    );
 }
 
 void MapperSxROM::writeCHR(NES_Address address, NES_Byte value) {

--- a/nes_emu/src/nes_emu/mappers/mapper_UxROM.cpp
+++ b/nes_emu/src/nes_emu/mappers/mapper_UxROM.cpp
@@ -23,6 +23,23 @@ NES_Byte MapperUxROM::readPRG(NES_Address address) {
     return fixed_prg.read(cartridge->getROM(), address, 0xc000);
 }
 
+const NES_Byte* MapperUxROM::getDirectPRGReadPage(NES_Address page_base) {
+    if (page_base < 0xc000) {
+        return switchable_prg.readPointer(
+            cartridge->getROM(),
+            page_base,
+            0x8000,
+            0x2000
+        );
+    }
+    return fixed_prg.readPointer(
+        cartridge->getROM(),
+        page_base,
+        0xc000,
+        0x2000
+    );
+}
+
 void MapperUxROM::writePRG(NES_Address address, NES_Byte value) {
     (void) address;
     // This implementation models no bus conflicts; MainBus resolves conflicts
@@ -34,6 +51,17 @@ NES_Byte MapperUxROM::readCHR(NES_Address address) {
     if (chr_memory.usesRAM())
         return chr_memory.read(address);
     return chr_rom.read(cartridge->getVROM(), address, 0x0000);
+}
+
+const NES_Byte* MapperUxROM::getDirectCHRReadPage(NES_Address page_base) {
+    if (chr_memory.usesRAM())
+        return chr_memory.readPointer(page_base, 0x0400);
+    return chr_rom.readPointer(
+        cartridge->getVROM(),
+        page_base,
+        0x0000,
+        0x0400
+    );
 }
 
 void MapperUxROM::writeCHR(NES_Address address, NES_Byte value) {

--- a/nes_emu/src/nes_emu/picture_bus.cpp
+++ b/nes_emu/src/nes_emu/picture_bus.cpp
@@ -10,12 +10,35 @@
 
 namespace NES {
 
+void PictureBus::refresh_direct_chr_read_pages() {
+    direct_chr_read_pages.fill(nullptr);
+    if (
+        mapper == nullptr ||
+        has_mapper_ppu_observers() ||
+        mapper_has_name_table_mapping
+    ) {
+        return;
+    }
+
+    for (std::size_t page = 0; page < direct_chr_read_pages.size(); ++page) {
+        NES_Address page_base = static_cast<NES_Address>(
+            page * DIRECT_CHR_READ_PAGE_SIZE
+        );
+        direct_chr_read_pages[page] = mapper->getDirectCHRReadPage(page_base);
+    }
+}
+
 NES_Byte PictureBus::read(NES_Address address) {
     address &= 0x3fff;
     if (address < 0x2000) {
         if (mapper_observes_ppu_addresses)
             mapper->onPPUAddress(address);
-        NES_Byte value = mapper->readCHR(address);
+        const NES_Byte* direct_page = direct_chr_read_pages[
+            address / DIRECT_CHR_READ_PAGE_SIZE
+        ];
+        NES_Byte value = direct_page == nullptr ?
+            mapper->readCHR(address) :
+            direct_page[address & (DIRECT_CHR_READ_PAGE_SIZE - 1)];
         if (mapper_observes_ppu_reads)
             mapper->onPPURead(address, value);
         return value;

--- a/nes_emu/src/nes_emu/picture_bus.cpp
+++ b/nes_emu/src/nes_emu/picture_bus.cpp
@@ -14,7 +14,12 @@ void PictureBus::refresh_direct_chr_read_pages() {
     direct_chr_read_pages.fill(nullptr);
     if (
         mapper == nullptr ||
-        has_mapper_ppu_observers() ||
+        mapper_observes_ppu_reads ||
+        mapper_observes_ppu_writes ||
+        (
+            mapper_observes_ppu_addresses &&
+            !mapper->allowsDirectCHRReadWithPPUAddressObservations()
+        ) ||
         mapper_has_name_table_mapping
     ) {
         return;

--- a/nes_emu/src/nes_emu/ppu.cpp
+++ b/nes_emu/src/nes_emu/ppu.cpp
@@ -36,6 +36,8 @@ void PPU::reset() {
     data_address_increment = 1;
     pipeline_state = PRE_RENDER;
     scanline_sprite_count = 0;
+    scanline_sprite_rows_cached = false;
+    scanline_sprite_rows_generation = 0;
     background_tile_cache_valid = false;
     background_tile_cache_address = 0;
     background_tile_cache_page = LOW;
@@ -45,6 +47,11 @@ void PPU::reset() {
     background_tile_cache_attribute = 0;
     std::fill(sprite_memory.begin(), sprite_memory.end(), 0);
     std::fill(scanline_sprites.begin(), scanline_sprites.end(), 0);
+    std::fill(
+        scanline_sprite_rows.begin(),
+        scanline_sprite_rows.end(),
+        SpriteRow()
+    );
     std::fill(&screen[0][0], &screen[0][0] + SCREEN_PIXEL_COUNT, 0);
 }
 
@@ -53,6 +60,9 @@ PPU::Snapshot PPU::save_state() const {
     snapshot.sprite_memory = sprite_memory;
     snapshot.scanline_sprites = scanline_sprites;
     snapshot.scanline_sprite_count = scanline_sprite_count;
+    snapshot.scanline_sprite_rows = scanline_sprite_rows;
+    snapshot.scanline_sprite_rows_cached = scanline_sprite_rows_cached;
+    snapshot.scanline_sprite_rows_generation = scanline_sprite_rows_generation;
     snapshot.pipeline_state = pipeline_state;
     snapshot.cycles = cycles;
     snapshot.scanline = scanline;
@@ -93,6 +103,9 @@ void PPU::load_state(const Snapshot& snapshot) {
     sprite_memory = snapshot.sprite_memory;
     scanline_sprites = snapshot.scanline_sprites;
     scanline_sprite_count = snapshot.scanline_sprite_count;
+    scanline_sprite_rows = snapshot.scanline_sprite_rows;
+    scanline_sprite_rows_cached = snapshot.scanline_sprite_rows_cached;
+    scanline_sprite_rows_generation = snapshot.scanline_sprite_rows_generation;
     pipeline_state = static_cast<PipelineState>(snapshot.pipeline_state);
     cycles = snapshot.cycles;
     scanline = snapshot.scanline;
@@ -127,6 +140,89 @@ void PPU::load_state(const Snapshot& snapshot) {
     std::copy(snapshot.screen.begin(), snapshot.screen.end(), &screen[0][0]);
 }
 
+void PPU::invalidate_sprite_rows() {
+    scanline_sprite_rows_cached = false;
+}
+
+NES_Address PPU::sprite_pattern_address(NES_Byte tile, int y_offset) const {
+    NES_Address address = 0;
+    if (!is_long_sprites) {
+        address = tile * 16 + y_offset;
+        if (sprite_page == HIGH)
+            address += 0x1000;
+    } else {
+        y_offset = (y_offset & 7) | ((y_offset & 8) << 1);
+        address = (tile >> 1) * 32 + y_offset;
+        address |= (tile & 1) << 12;
+    }
+    return address;
+}
+
+void PPU::prefetch_scanline_sprite_rows(PictureBus& bus) {
+    std::fill(
+        scanline_sprite_rows.begin(),
+        scanline_sprite_rows.end(),
+        SpriteRow()
+    );
+    scanline_sprite_rows_generation = bus.get_write_generation();
+
+    const int length = is_long_sprites ? 16 : 8;
+    for (std::size_t row_index = 0; row_index < scanline_sprite_count;
+            ++row_index) {
+        const NES_Byte sprite_index = scanline_sprites[row_index];
+        const std::size_t oam_index = sprite_index * 4;
+        NES_Byte tile = sprite_memory[oam_index + 1];
+        NES_Byte attribute = sprite_memory[oam_index + 2];
+        int y_offset = scanline - sprite_memory[oam_index];
+        if ((attribute & 0x80) != 0)
+            y_offset ^= (length - 1);
+
+        const NES_Address address = sprite_pattern_address(tile, y_offset);
+        SpriteRow& row = scanline_sprite_rows[row_index];
+        row.sprite_index = sprite_index;
+        row.x = sprite_memory[oam_index + 3];
+        row.attribute = attribute;
+        row.pattern_low = bus.read(address);
+        row.pattern_high = bus.read(address + 8);
+        row.palette_base = 0x10 | ((attribute & 0x3) << 2);
+        row.foreground = !(attribute & 0x20);
+        for (int pixel = 0; pixel < 8; ++pixel) {
+            int x_shift = pixel;
+            if ((attribute & 0x40) == 0)
+                x_shift ^= 7;
+            row.pixels[pixel] = (row.pattern_low >> x_shift) & 1;
+            row.pixels[pixel] |= (
+                (row.pattern_high >> x_shift) & 1
+            ) << 1;
+        }
+        row.valid = true;
+    }
+    scanline_sprite_rows_cached = true;
+}
+
+void PPU::evaluate_scanline_sprites(PictureBus& bus) {
+    scanline_sprite_count = 0;
+    std::fill(scanline_sprites.begin(), scanline_sprites.end(), 0);
+    invalidate_sprite_rows();
+
+    const int range = is_long_sprites ? 16 : 8;
+    for (NES_Byte i = sprite_data_address / 4; i < 64; ++i) {
+        auto diff = (scanline - sprite_memory[i * 4]);
+        if (0 <= diff && diff < range) {
+            scanline_sprites[scanline_sprite_count++] = i;
+            if (scanline_sprite_count >= MAX_SCANLINE_SPRITES)
+                break;
+        }
+    }
+
+    if (
+        is_showing_sprites &&
+        scanline_sprite_count >= SPRITE_PREFETCH_MIN_SPRITES &&
+        bus.can_prefetch_sprite_rows()
+    )
+        prefetch_scanline_sprite_rows(bus);
+}
+
 void PPU::cycle(PictureBus& bus) {
     switch (pipeline_state) {
         case PRE_RENDER: {
@@ -156,7 +252,7 @@ void PPU::cycle(PictureBus& bus) {
         case RENDER: {
             if (cycles > 0 && cycles <= SCANLINE_VISIBLE_DOTS) {
                 NES_Byte bgColor = 0, sprColor = 0;
-                bool bgOpaque = false, sprOpaque = true;
+                bool bgOpaque = false, sprOpaque = false;
                 bool spriteForeground = false;
 
                 int x = cycles - 1;
@@ -244,58 +340,92 @@ void PPU::cycle(PictureBus& bus) {
                 }
 
                 if (is_showing_sprites && (!is_hiding_edge_sprites || x >= 8)) {
-                    for (std::size_t sprite_index = 0; sprite_index < scanline_sprite_count; ++sprite_index) {
-                        NES_Byte i = scanline_sprites[sprite_index];
-                        NES_Byte spr_x =     sprite_memory[i * 4 + 3];
+                    bool use_cached_rows = scanline_sprite_rows_cached;
+                    if (
+                        use_cached_rows &&
+                        scanline_sprite_rows_generation !=
+                            bus.get_write_generation()
+                    ) {
+                        invalidate_sprite_rows();
+                        use_cached_rows = false;
+                    }
 
-                        if (0 > x - spr_x || x - spr_x >= 8)
-                            continue;
+                    if (use_cached_rows) {
+                        for (std::size_t row_index = 0;
+                                row_index < scanline_sprite_count;
+                                ++row_index) {
+                            const SpriteRow& row =
+                                scanline_sprite_rows[row_index];
+                            if (!row.valid)
+                                continue;
 
-                        NES_Byte spr_y     = sprite_memory[i * 4 + 0] + 1,
-                             tile      = sprite_memory[i * 4 + 1],
-                             attribute = sprite_memory[i * 4 + 2];
+                            if (0 > x - row.x || x - row.x >= 8)
+                                continue;
 
-                        int length = (is_long_sprites) ? 16 : 8;
+                            NES_Byte candidate = row.pixels[x - row.x];
 
-                        int x_shift = (x - spr_x) % 8, y_offset = (y - spr_y) % length;
+                            if (!(sprOpaque = candidate)) {
+                                sprColor = 0;
+                                continue;
+                            }
 
-                        if ((attribute & 0x40) == 0) //If NOT flipping horizontally
-                            x_shift ^= 7;
-                        if ((attribute & 0x80) != 0) //IF flipping vertically
-                            y_offset ^= (length - 1);
+                            sprColor = row.palette_base | candidate;
+                            spriteForeground = row.foreground;
 
-                        NES_Address address = 0;
+                            if (
+                                !is_sprite_zero_hit &&
+                                is_showing_background &&
+                                row.sprite_index == 0 &&
+                                sprOpaque &&
+                                bgOpaque
+                            )
+                                is_sprite_zero_hit = true;
 
-                        if (!is_long_sprites) {
-                            address = tile * 16 + y_offset;
-                            if (sprite_page == HIGH) address += 0x1000;
+                            break;
                         }
-                        // 8 x 16 sprites
-                        else {
-                            //bit-3 is one if it is the bottom tile of the sprite, multiply by two to get the next pattern
-                            y_offset = (y_offset & 7) | ((y_offset & 8) << 1);
-                            address = (tile >> 1) * 32 + y_offset;
-                            address |= (tile & 1) << 12; //Bank 0x1000 if bit-0 is high
+                    } else {
+                        for (std::size_t sprite_index = 0; sprite_index < scanline_sprite_count; ++sprite_index) {
+                            NES_Byte i = scanline_sprites[sprite_index];
+                            NES_Byte spr_x =     sprite_memory[i * 4 + 3];
+
+                            if (0 > x - spr_x || x - spr_x >= 8)
+                                continue;
+
+                            NES_Byte spr_y     = sprite_memory[i * 4 + 0] + 1,
+                                 tile      = sprite_memory[i * 4 + 1],
+                                 attribute = sprite_memory[i * 4 + 2];
+
+                            int length = (is_long_sprites) ? 16 : 8;
+
+                            int x_shift = (x - spr_x) % 8, y_offset = (y - spr_y) % length;
+
+                            if ((attribute & 0x40) == 0) //If NOT flipping horizontally
+                                x_shift ^= 7;
+                            if ((attribute & 0x80) != 0) //IF flipping vertically
+                                y_offset ^= (length - 1);
+
+                            NES_Address address =
+                                sprite_pattern_address(tile, y_offset);
+
+                            sprColor = (bus.read(address) >> (x_shift)) & 1; //bit 0 of palette entry
+                            sprColor |= ((bus.read(address + 8) >> (x_shift)) & 1) << 1; //bit 1
+
+                            if (!(sprOpaque = sprColor)) {
+                                sprColor = 0;
+                                continue;
+                            }
+
+                            sprColor |= 0x10; //Select sprite palette
+                            sprColor |= (attribute & 0x3) << 2; //bits 2-3
+
+                            spriteForeground = !(attribute & 0x20);
+
+                            //Sprite-0 hit detection
+                            if (!is_sprite_zero_hit && is_showing_background && i == 0 && sprOpaque && bgOpaque)
+                                is_sprite_zero_hit = true;
+
+                            break; //Exit the loop now since we've found the highest priority sprite
                         }
-
-                        sprColor |= (bus.read(address) >> (x_shift)) & 1; //bit 0 of palette entry
-                        sprColor |= ((bus.read(address + 8) >> (x_shift)) & 1) << 1; //bit 1
-
-                        if (!(sprOpaque = sprColor)) {
-                            sprColor = 0;
-                            continue;
-                        }
-
-                        sprColor |= 0x10; //Select sprite palette
-                        sprColor |= (attribute & 0x3) << 2; //bits 2-3
-
-                        spriteForeground = !(attribute & 0x20);
-
-                        //Sprite-0 hit detection
-                        if (!is_sprite_zero_hit && is_showing_background && i == 0 && sprOpaque && bgOpaque)
-                            is_sprite_zero_hit = true;
-
-                        break; //Exit the loop now since we've found the highest priority sprite
                     }
                 }
                 // get the address of the color in the palette
@@ -344,25 +474,7 @@ void PPU::cycle(PictureBus& bus) {
 //                     sprite_data_address = 0;
 
             if (cycles >= SCANLINE_END_CYCLE) {
-                //Find and index sprites that are on the next Scanline
-                //This isn't where/when this indexing, actually copying in 2C02 is done
-                //but (I think) it shouldn't hurt any games if this is done here
-
-                scanline_sprite_count = 0;
-                std::fill(scanline_sprites.begin(), scanline_sprites.end(), 0);
-
-                int range = 8;
-                if (is_long_sprites)
-                    range = 16;
-
-                for (NES_Byte i = sprite_data_address / 4; i < 64; ++i) {
-                    auto diff = (scanline - sprite_memory[i * 4]);
-                    if (0 <= diff && diff < range) {
-                        scanline_sprites[scanline_sprite_count++] = i;
-                        if (scanline_sprite_count >= MAX_SCANLINE_SPRITES)
-                            break;
-                    }
-                }
+                evaluate_scanline_sprites(bus);
                 background_tile_cache_valid = false;
 
                 ++scanline;
@@ -420,6 +532,7 @@ void PPU::do_DMA(const NES_Byte* page_ptr) {
             page_ptr + (256 - sprite_data_address),
             sprite_data_address
         );
+    invalidate_sprite_rows();
 }
 
 void PPU::control(NES_Byte ctrl) {
@@ -428,6 +541,7 @@ void PPU::control(NES_Byte ctrl) {
     background_page = static_cast<CharacterPage>(!!(ctrl & 0x10));
     sprite_page = static_cast<CharacterPage>(!!(ctrl & 0x8));
     background_tile_cache_valid = false;
+    invalidate_sprite_rows();
     if (ctrl & 0x4)
         data_address_increment = 0x20;
     else
@@ -447,6 +561,7 @@ void PPU::set_mask(NES_Byte mask) {
     is_showing_background = mask & 0x8;
     is_showing_sprites = mask & 0x10;
     background_tile_cache_valid = false;
+    invalidate_sprite_rows();
 }
 
 NES_Byte PPU::get_status() {

--- a/nes_emu/src/nes_emu/ppu.cpp
+++ b/nes_emu/src/nes_emu/ppu.cpp
@@ -11,6 +11,23 @@
 #include "nes_emu/palette.hpp"
 #include "nes_emu/log.hpp"
 
+namespace {
+
+inline NES::NES_Byte reverse_background_bits(NES::NES_Byte value) {
+    value = static_cast<NES::NES_Byte>(
+        ((value & 0xf0) >> 4) | ((value & 0x0f) << 4)
+    );
+    value = static_cast<NES::NES_Byte>(
+        ((value & 0xcc) >> 2) | ((value & 0x33) << 2)
+    );
+    value = static_cast<NES::NES_Byte>(
+        ((value & 0xaa) >> 1) | ((value & 0x55) << 1)
+    );
+    return value;
+}
+
+}  // namespace
+
 namespace NES {
 
 void PPU::reset() {
@@ -45,6 +62,10 @@ void PPU::reset() {
     background_tile_cache_low = 0;
     background_tile_cache_high = 0;
     background_tile_cache_attribute = 0;
+    background_tile_cache_low_bits = 0;
+    background_tile_cache_high_bits = 0;
+    background_tile_cache_palette_high = 0;
+    background_tile_cache_opaque_mask = 0;
     std::fill(sprite_memory.begin(), sprite_memory.end(), 0);
     std::fill(scanline_sprites.begin(), scanline_sprites.end(), 0);
     std::fill(
@@ -91,6 +112,12 @@ PPU::Snapshot PPU::save_state() const {
     snapshot.background_tile_cache_low = background_tile_cache_low;
     snapshot.background_tile_cache_high = background_tile_cache_high;
     snapshot.background_tile_cache_attribute = background_tile_cache_attribute;
+    snapshot.background_tile_cache_low_bits = background_tile_cache_low_bits;
+    snapshot.background_tile_cache_high_bits = background_tile_cache_high_bits;
+    snapshot.background_tile_cache_palette_high =
+        background_tile_cache_palette_high;
+    snapshot.background_tile_cache_opaque_mask =
+        background_tile_cache_opaque_mask;
     std::copy(
         &screen[0][0],
         &screen[0][0] + SCREEN_PIXEL_COUNT,
@@ -137,6 +164,12 @@ void PPU::load_state(const Snapshot& snapshot) {
     background_tile_cache_low = snapshot.background_tile_cache_low;
     background_tile_cache_high = snapshot.background_tile_cache_high;
     background_tile_cache_attribute = snapshot.background_tile_cache_attribute;
+    background_tile_cache_low_bits = snapshot.background_tile_cache_low_bits;
+    background_tile_cache_high_bits = snapshot.background_tile_cache_high_bits;
+    background_tile_cache_palette_high =
+        snapshot.background_tile_cache_palette_high;
+    background_tile_cache_opaque_mask =
+        snapshot.background_tile_cache_opaque_mask;
     std::copy(snapshot.screen.begin(), snapshot.screen.end(), &screen[0][0]);
 }
 
@@ -223,6 +256,45 @@ void PPU::evaluate_scanline_sprites(PictureBus& bus) {
         prefetch_scanline_sprite_rows(bus);
 }
 
+void PPU::invalidate_background_tile_cache() {
+    background_tile_cache_valid = false;
+}
+
+void PPU::fill_background_tile_cache(
+    PictureBus& bus,
+    std::uint64_t generation
+) {
+    NES_Address address = 0x2000 | (data_address & 0x0FFF);
+    NES_Byte tile = bus.read(address);
+
+    address = (tile * 16) + ((data_address >> 12) & 0x7);
+    address |= background_page << 12;
+    NES_Byte pattern_low = bus.read(address);
+    NES_Byte pattern_high = bus.read(address + 8);
+
+    address = 0x23C0 | (data_address & 0x0C00) |
+        ((data_address >> 4) & 0x38) |
+        ((data_address >> 2) & 0x07);
+    NES_Byte attribute = bus.read(address);
+
+    background_tile_cache_valid = true;
+    background_tile_cache_address = data_address;
+    background_tile_cache_page = background_page;
+    background_tile_cache_generation = generation;
+    background_tile_cache_low = pattern_low;
+    background_tile_cache_high = pattern_high;
+    background_tile_cache_attribute = attribute;
+    background_tile_cache_low_bits = reverse_background_bits(pattern_low);
+    background_tile_cache_high_bits = reverse_background_bits(pattern_high);
+
+    const int attribute_shift =
+        ((data_address >> 4) & 4) | (data_address & 2);
+    background_tile_cache_palette_high =
+        static_cast<NES_Byte>(((attribute >> attribute_shift) & 0x3) << 2);
+    background_tile_cache_opaque_mask =
+        background_tile_cache_low_bits | background_tile_cache_high_bits;
+}
+
 void PPU::cycle(PictureBus& bus) {
     switch (pipeline_state) {
         case PRE_RENDER: {
@@ -232,13 +304,13 @@ void PPU::cycle(PictureBus& bus) {
                 // Set bits related to horizontal position
                 data_address &= ~0x41f; //Unset horizontal bits
                 data_address |= temp_address & 0x41f; //Copy
-                background_tile_cache_valid = false;
+                invalidate_background_tile_cache();
             }
             else if (cycles > 280 && cycles <= 304 && is_showing_background && is_showing_sprites) {
                 // Set vertical bits
                 data_address &= ~0x7be0; //Unset bits related to horizontal
                 data_address |= temp_address & 0x7be0; //Copy
-                background_tile_cache_valid = false;
+                invalidate_background_tile_cache();
             }
             // if (cycles > 257 && cycles < 320)
             //     sprite_data_address = 0;
@@ -261,22 +333,27 @@ void PPU::cycle(PictureBus& bus) {
                 if (is_showing_background) {
                     auto x_fine = (fine_x_scroll + x) % 8;
                     if (!is_hiding_edge_background || x >= 8) {
-                        NES_Byte pattern_low = 0;
-                        NES_Byte pattern_high = 0;
-                        NES_Byte attribute = 0;
                         bool can_cache = !bus.has_mapper_ppu_observers();
                         auto generation = bus.get_write_generation();
 
-                        if (
-                            can_cache &&
-                            background_tile_cache_valid &&
-                            background_tile_cache_address == data_address &&
-                            background_tile_cache_page == background_page &&
-                            background_tile_cache_generation == generation
-                        ) {
-                            pattern_low = background_tile_cache_low;
-                            pattern_high = background_tile_cache_high;
-                            attribute = background_tile_cache_attribute;
+                        if (can_cache) {
+                            if (
+                                !background_tile_cache_valid ||
+                                background_tile_cache_address != data_address ||
+                                background_tile_cache_page != background_page ||
+                                background_tile_cache_generation != generation
+                            )
+                                fill_background_tile_cache(bus, generation);
+
+                            const NES_Byte fine_mask =
+                                static_cast<NES_Byte>(1 << x_fine);
+                            bgColor = background_tile_cache_palette_high;
+                            if (background_tile_cache_low_bits & fine_mask)
+                                bgColor |= 1;
+                            if (background_tile_cache_high_bits & fine_mask)
+                                bgColor |= 2;
+                            bgOpaque =
+                                background_tile_cache_opaque_mask & fine_mask;
                         } else {
                             // fetch tile
                             // mask off fine y
@@ -289,39 +366,28 @@ void PPU::cycle(PictureBus& bus) {
                             address = (tile * 16) + ((data_address >> 12/*y % 8*/) & 0x7);
                             //set whether the pattern is in the high or low page
                             address |= background_page << 12;
-                            pattern_low = bus.read(address);
-                            pattern_high = bus.read(address + 8);
+                            NES_Byte pattern_low = bus.read(address);
+                            NES_Byte pattern_high = bus.read(address + 8);
 
                             //fetch attribute and calculate higher two bits of palette
                             address = 0x23C0 | (data_address & 0x0C00) | ((data_address >> 4) & 0x38)
                                         | ((data_address >> 2) & 0x07);
-                            attribute = bus.read(address);
+                            NES_Byte attribute = bus.read(address);
 
-                            if (can_cache) {
-                                background_tile_cache_valid = true;
-                                background_tile_cache_address = data_address;
-                                background_tile_cache_page = background_page;
-                                background_tile_cache_generation = generation;
-                                background_tile_cache_low = pattern_low;
-                                background_tile_cache_high = pattern_high;
-                                background_tile_cache_attribute = attribute;
-                            } else {
-                                background_tile_cache_valid = false;
-                            }
+                            //Get the corresponding bit determined by (8 - x_fine) from the right
+                            //bit 0 of palette entry
+                            bgColor = (pattern_low >> (7 ^ x_fine)) & 1;
+                            //bit 1
+                            bgColor |= ((pattern_high >> (7 ^ x_fine)) & 1) << 1;
+
+                            //flag used to calculate final pixel with the sprite pixel
+                            bgOpaque = bgColor;
+
+                            int shift = ((data_address >> 4) & 4) | (data_address & 2);
+                            //Extract and set the upper two bits for the color
+                            bgColor |= ((attribute >> shift) & 0x3) << 2;
+                            invalidate_background_tile_cache();
                         }
-
-                        //Get the corresponding bit determined by (8 - x_fine) from the right
-                        //bit 0 of palette entry
-                        bgColor = (pattern_low >> (7 ^ x_fine)) & 1;
-                        //bit 1
-                        bgColor |= ((pattern_high >> (7 ^ x_fine)) & 1) << 1;
-
-                        //flag used to calculate final pixel with the sprite pixel
-                        bgOpaque = bgColor;
-
-                        int shift = ((data_address >> 4) & 4) | (data_address & 2);
-                        //Extract and set the upper two bits for the color
-                        bgColor |= ((attribute >> shift) & 0x3) << 2;
                     }
                     //Increment/wrap coarse X
                     if (x_fine == 7) {
@@ -335,7 +401,7 @@ void PPU::cycle(PictureBus& bus) {
                         else
                             // increment coarse X
                             data_address += 1;
-                        background_tile_cache_valid = false;
+                        invalidate_background_tile_cache();
                     }
                 }
 
@@ -467,7 +533,7 @@ void PPU::cycle(PictureBus& bus) {
                 // Copy bits related to horizontal position
                 data_address &= ~0x41f;
                 data_address |= temp_address & 0x41f;
-                background_tile_cache_valid = false;
+                invalidate_background_tile_cache();
             }
 
 //                 if (cycles > 257 && cycles < 320)
@@ -475,7 +541,7 @@ void PPU::cycle(PictureBus& bus) {
 
             if (cycles >= SCANLINE_END_CYCLE) {
                 evaluate_scanline_sprites(bus);
-                background_tile_cache_valid = false;
+                invalidate_background_tile_cache();
 
                 ++scanline;
                 cycles = 0;
@@ -540,7 +606,7 @@ void PPU::control(NES_Byte ctrl) {
     is_long_sprites = ctrl & 0x20;
     background_page = static_cast<CharacterPage>(!!(ctrl & 0x10));
     sprite_page = static_cast<CharacterPage>(!!(ctrl & 0x8));
-    background_tile_cache_valid = false;
+    invalidate_background_tile_cache();
     invalidate_sprite_rows();
     if (ctrl & 0x4)
         data_address_increment = 0x20;
@@ -560,7 +626,7 @@ void PPU::set_mask(NES_Byte mask) {
     is_hiding_edge_sprites = !(mask & 0x4);
     is_showing_background = mask & 0x8;
     is_showing_sprites = mask & 0x10;
-    background_tile_cache_valid = false;
+    invalidate_background_tile_cache();
     invalidate_sprite_rows();
 }
 
@@ -585,7 +651,7 @@ void PPU::set_data_address(NES_Byte address) {
         temp_address |= address;
         data_address = temp_address;
         is_first_write = true;
-        background_tile_cache_valid = false;
+        invalidate_background_tile_cache();
     }
 }
 
@@ -602,7 +668,7 @@ NES_Byte PPU::get_data(PictureBus& bus) {
 
 void PPU::set_data(PictureBus& bus, NES_Byte data) {
     bus.write(data_address, data);
-    background_tile_cache_valid = false;
+    invalidate_background_tile_cache();
     data_address += data_address_increment;
 }
 
@@ -612,12 +678,12 @@ void PPU::set_scroll(NES_Byte scroll) {
         temp_address |= (scroll >> 3) & 0x1f;
         fine_x_scroll = scroll & 0x7;
         is_first_write = false;
-        background_tile_cache_valid = false;
+        invalidate_background_tile_cache();
     } else {
         temp_address &= ~0x73e0;
         temp_address |= ((scroll & 0x7) << 12) | ((scroll & 0xf8) << 2);
         is_first_write = true;
-        background_tile_cache_valid = false;
+        invalidate_background_tile_cache();
     }
 }
 

--- a/nes_emu/src/nes_emu/ppu.cpp
+++ b/nes_emu/src/nes_emu/ppu.cpp
@@ -333,7 +333,7 @@ void PPU::cycle(PictureBus& bus) {
                 if (is_showing_background) {
                     auto x_fine = (fine_x_scroll + x) % 8;
                     if (!is_hiding_edge_background || x >= 8) {
-                        bool can_cache = !bus.has_mapper_ppu_observers();
+                        bool can_cache = bus.can_cache_background_tile_rows();
                         auto generation = bus.get_write_generation();
 
                         if (can_cache) {

--- a/nes_emu/test/nes_emu/mappers/test_mapper_CNROM.cpp
+++ b/nes_emu/test/nes_emu/mappers/test_mapper_CNROM.cpp
@@ -19,11 +19,16 @@ TEST_CASE("mapper 003 CNROM switches CHR banks and masks selects", "[mapper][cnr
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(0));
     REQUIRE(mapper->readPRG(0xd000) == NESTest::prg_bank_marker(1));
     REQUIRE(mapper->readCHR(0x0100) == NESTest::chr_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0xd000) == NESTest::prg_bank_marker(1));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0100) == NESTest::chr_bank_marker(0));
 
     mapper->writePRG(0x8000, 0x02);
     REQUIRE(mapper->readCHR(0x0100) == NESTest::chr_bank_marker(2));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0100) == NESTest::chr_bank_marker(2));
     mapper->writePRG(0x8000, 0x03);
     REQUIRE(mapper->readCHR(0x0100) == NESTest::chr_bank_marker(3));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0100) == NESTest::chr_bank_marker(3));
 }
 
 TEST_CASE("mapper 003 masks CHR bank selects to available banks", "[mapper][cnrom]") {
@@ -33,6 +38,7 @@ TEST_CASE("mapper 003 masks CHR bank selects to available banks", "[mapper][cnro
 
     mapper->writePRG(0x8000, 0x03);
     REQUIRE(mapper->readCHR(0x0100) == NESTest::chr_bank_marker(1));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0100) == NESTest::chr_bank_marker(1));
 }
 
 TEST_CASE("mapper 003 emulator save-state preserves selected CHR bank", "[mapper][cnrom]") {
@@ -57,4 +63,7 @@ TEST_CASE("mapper 003 emulator save-state preserves selected CHR bank", "[mapper
     REQUIRE(restored.readPRG(0x9000) == NESTest::prg_bank_marker(0));
     REQUIRE(restored.readPRG(0xd000) == NESTest::prg_bank_marker(1));
     REQUIRE(restored.readCHR(0x0100) == NESTest::chr_bank_marker(2));
+    REQUIRE(NESTest::direct_prg_read(restored, 0x9000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(restored, 0xd000) == NESTest::prg_bank_marker(1));
+    REQUIRE(NESTest::direct_chr_read(restored, 0x0100) == NESTest::chr_bank_marker(2));
 }

--- a/nes_emu/test/nes_emu/mappers/test_mapper_MMC3.cpp
+++ b/nes_emu/test/nes_emu/mappers/test_mapper_MMC3.cpp
@@ -118,6 +118,43 @@ TEST_CASE("mapper 004 MMC3 switches 2 KiB and 1 KiB CHR banks", "[mapper][mmc3]"
     REQUIRE(mapper->readCHR(0x1c00) == NESTest::chr_kib_marker(9));
 }
 
+TEST_CASE("mapper 004 MMC3 direct CHR pages stay valid with A12 observation", "[mapper][mmc3]") {
+    NESTest::TemporaryROM rom(
+        "mmc3_direct_chr_pages",
+        4,
+        2,
+        2,
+        "horizontal",
+        false,
+        false,
+        true
+    );
+    NES::Cartridge cartridge = rom.load();
+    std::unique_ptr<NES::Mapper> mapper = NESTest::mapper_for(cartridge);
+
+    REQUIRE(mapper->observesPPUAddresses());
+    REQUIRE(mapper->allowsDirectCHRReadWithPPUAddressObservations());
+    REQUIRE(mapper->allowsBackgroundTileCacheWithPPUAddressObservations());
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0000) == NESTest::chr_kib_marker(0));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0400) == NESTest::chr_kib_marker(1));
+
+    write_mmc3_bank(*mapper, 0, 7);
+    write_mmc3_bank(*mapper, 1, 8);
+    write_mmc3_bank(*mapper, 2, 10);
+    write_mmc3_bank(*mapper, 3, 11);
+    write_mmc3_bank(*mapper, 4, 12);
+    write_mmc3_bank(*mapper, 5, 13);
+
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0000) == NESTest::chr_kib_marker(6));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0400) == NESTest::chr_kib_marker(7));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0800) == NESTest::chr_kib_marker(8));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0c00) == NESTest::chr_kib_marker(9));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x1000) == NESTest::chr_kib_marker(10));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x1400) == NESTest::chr_kib_marker(11));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x1800) == NESTest::chr_kib_marker(12));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x1c00) == NESTest::chr_kib_marker(13));
+}
+
 TEST_CASE("mapper 004 MMC3 controls mirroring except four-screen carts", "[mapper][mmc3]") {
     NESTest::TemporaryROM rom("mmc3_mirroring", 4, 2, 1);
     NES::Cartridge cartridge = rom.load();
@@ -201,6 +238,28 @@ TEST_CASE("mapper 004 MMC3 clocks IRQs from filtered PPU A12 edges", "[mapper][m
     mapper->writePRG(0xe001, 0x00);
     filtered_a12_clock(*mapper);
     REQUIRE(irq_count == 2);
+}
+
+TEST_CASE("mapper 004 MMC3 only invalidates direct pages for bank-affecting writes", "[mapper][mmc3]") {
+    NESTest::TemporaryROM rom("mmc3_direct_page_invalidation", 4, 2, 1);
+    NES::Cartridge cartridge = rom.load();
+    std::unique_ptr<NES::Mapper> mapper = NESTest::mapper_for(cartridge);
+
+    REQUIRE(mapper->invalidatesDirectPRGReadPagesOnWrite(0x8000, 0x00));
+    REQUIRE(mapper->invalidatesDirectCHRReadPagesOnWrite(0x8000, 0x00));
+
+    mapper->writePRG(0x8000, 0x02);
+    REQUIRE_FALSE(mapper->invalidatesDirectPRGReadPagesOnWrite(0x8001, 0x00));
+    REQUIRE(mapper->invalidatesDirectCHRReadPagesOnWrite(0x8001, 0x00));
+
+    mapper->writePRG(0x8000, 0x06);
+    REQUIRE(mapper->invalidatesDirectPRGReadPagesOnWrite(0x8001, 0x00));
+    REQUIRE_FALSE(mapper->invalidatesDirectCHRReadPagesOnWrite(0x8001, 0x00));
+
+    REQUIRE_FALSE(mapper->invalidatesDirectPRGReadPagesOnWrite(0xc000, 0x00));
+    REQUIRE_FALSE(mapper->invalidatesDirectCHRReadPagesOnWrite(0xc000, 0x00));
+    REQUIRE_FALSE(mapper->invalidatesDirectPRGReadPagesOnWrite(0xe001, 0x00));
+    REQUIRE_FALSE(mapper->invalidatesDirectCHRReadPagesOnWrite(0xe001, 0x00));
 }
 
 TEST_CASE("mapper 004 MMC3 clone preserves mapper state", "[mapper][mmc3]") {

--- a/nes_emu/test/nes_emu/mappers/test_mapper_NROM.cpp
+++ b/nes_emu/test/nes_emu/mappers/test_mapper_NROM.cpp
@@ -19,6 +19,9 @@ TEST_CASE("mapper 000 NROM maps fixed PRG and CHR data", "[mapper][nrom]") {
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(0));
     REQUIRE(mapper->readPRG(0xd000) == NESTest::prg_bank_marker(1));
     REQUIRE(mapper->readCHR(0x0100) == NESTest::chr_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0xd000) == NESTest::prg_bank_marker(1));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0100) == NESTest::chr_bank_marker(0));
     REQUIRE(mapper->getNameTableMirroring() == NES::VERTICAL);
 }
 
@@ -29,12 +32,24 @@ TEST_CASE("mapper 000 mirrors 16 KiB PRG and snapshots PRG RAM", "[mapper][nrom]
 
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(0));
     REQUIRE(mapper->readPRG(0xd000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0xd000) == NESTest::prg_bank_marker(0));
 
     mapper->writePRGRAM(0x6000, 0x2a);
     std::unique_ptr<NES::Mapper> backup = mapper->clone();
     mapper->writePRGRAM(0x6000, 0x7f);
     REQUIRE(mapper->readPRGRAM(0x6000) == 0x7f);
     REQUIRE(backup->readPRGRAM(0x6000) == 0x2a);
+}
+
+TEST_CASE("mapper 000 direct CHR RAM reads observe writes", "[mapper][nrom]") {
+    NESTest::TemporaryROM rom("nrom_chr_ram_direct", 0, 1, 0);
+    NES::Cartridge cartridge = rom.load();
+    std::unique_ptr<NES::Mapper> mapper = NESTest::mapper_for(cartridge);
+
+    mapper->writeCHR(0x0456, 0x6d);
+    REQUIRE(mapper->readCHR(0x0456) == 0x6d);
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0456) == 0x6d);
 }
 
 TEST_CASE("mapper 000 emulator save-state preserves PRG RAM", "[mapper][nrom]") {
@@ -61,6 +76,8 @@ TEST_CASE("mapper 000 emulator save-state preserves PRG RAM", "[mapper][nrom]") 
     NES::Mapper& restored = NES::EmulatorInspector::mapper(emulator);
     REQUIRE(restored.readPRGRAM(0x6000) == 0x33);
     REQUIRE(restored.readPRGRAM(0x7fff) == 0x44);
+    REQUIRE(NESTest::direct_prg_read(restored, 0x9000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(restored, 0xd000) == NESTest::prg_bank_marker(1));
     REQUIRE(restored.getNameTableMirroring() == NES::VERTICAL);
 
     restored.writePRGRAM(0x6000, 0x55);

--- a/nes_emu/test/nes_emu/mappers/test_mapper_SxROM.cpp
+++ b/nes_emu/test/nes_emu/mappers/test_mapper_SxROM.cpp
@@ -21,12 +21,16 @@ TEST_CASE(
 
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(0));
     REQUIRE(mapper->readPRG(0xd000) == NESTest::prg_bank_marker(3));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0xd000) == NESTest::prg_bank_marker(3));
 
     NESTest::write_mmc1_register(*mapper, 0x8000, 0x0e);
     REQUIRE(mapper->getNameTableMirroring() == NES::VERTICAL);
     NESTest::write_mmc1_register(*mapper, 0xe000, 0x02);
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(2));
     REQUIRE(mapper->readPRG(0xd000) == NESTest::prg_bank_marker(3));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(2));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0xd000) == NESTest::prg_bank_marker(3));
 
     NESTest::write_mmc1_register(*mapper, 0x8000, 0x0f);
     REQUIRE(mapper->getNameTableMirroring() == NES::HORIZONTAL);
@@ -95,12 +99,16 @@ TEST_CASE("mapper 001 supports 4 KiB and 8 KiB CHR banking", "[mapper][sxrom]") 
     NESTest::write_mmc1_register(*mapper, 0xa000, 0x03);
     REQUIRE(mapper->readCHR(0x0000) == NESTest::chr_page_marker(2));
     REQUIRE(mapper->readCHR(0x1000) == NESTest::chr_page_marker(3));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0000) == NESTest::chr_page_marker(2));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x1000) == NESTest::chr_page_marker(3));
 
     NESTest::write_mmc1_register(*mapper, 0x8000, 0x1e);
     NESTest::write_mmc1_register(*mapper, 0xa000, 0x05);
     NESTest::write_mmc1_register(*mapper, 0xc000, 0x06);
     REQUIRE(mapper->readCHR(0x0000) == NESTest::chr_page_marker(5));
     REQUIRE(mapper->readCHR(0x1000) == NESTest::chr_page_marker(6));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0000) == NESTest::chr_page_marker(5));
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x1000) == NESTest::chr_page_marker(6));
 }
 
 TEST_CASE("mapper 001 protects PRG RAM and clones CHR RAM state", "[mapper][sxrom]") {
@@ -132,6 +140,9 @@ TEST_CASE("mapper 001 protects PRG RAM and clones CHR RAM state", "[mapper][sxro
     REQUIRE(backup->readPRG(0x9000) == NESTest::prg_bank_marker(1));
     REQUIRE(backup->readPRG(0xd000) == NESTest::prg_bank_marker(3));
     REQUIRE(backup->readCHR(0x0123) == 0x5a);
+    REQUIRE(NESTest::direct_prg_read(*backup, 0x9000) == NESTest::prg_bank_marker(1));
+    REQUIRE(NESTest::direct_prg_read(*backup, 0xd000) == NESTest::prg_bank_marker(3));
+    REQUIRE(NESTest::direct_chr_read(*backup, 0x0123) == 0x5a);
     REQUIRE(backup->getNameTableMirroring() == NES::HORIZONTAL);
 }
 
@@ -163,6 +174,9 @@ TEST_CASE("mapper 001 emulator save-state preserves MMC1 state", "[mapper][sxrom
     REQUIRE(restored.readPRG(0x9000) == NESTest::prg_bank_marker(1));
     REQUIRE(restored.readPRG(0xd000) == NESTest::prg_bank_marker(3));
     REQUIRE(restored.readCHR(0x0123) == 0x5a);
+    REQUIRE(NESTest::direct_prg_read(restored, 0x9000) == NESTest::prg_bank_marker(1));
+    REQUIRE(NESTest::direct_prg_read(restored, 0xd000) == NESTest::prg_bank_marker(3));
+    REQUIRE(NESTest::direct_chr_read(restored, 0x0123) == 0x5a);
     REQUIRE(restored.readPRGRAM(0x6000) == 0x33);
     REQUIRE(restored.getNameTableMirroring() == NES::HORIZONTAL);
 

--- a/nes_emu/test/nes_emu/mappers/test_mapper_UxROM.cpp
+++ b/nes_emu/test/nes_emu/mappers/test_mapper_UxROM.cpp
@@ -18,16 +18,22 @@ TEST_CASE("mapper 002 UxROM switches PRG and provides CHR RAM", "[mapper][uxrom]
 
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(0));
     REQUIRE(mapper->readPRG(0xd000) == NESTest::prg_bank_marker(3));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(0));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0xd000) == NESTest::prg_bank_marker(3));
 
     mapper->writePRG(0x8000, 0x02);
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(2));
     REQUIRE(mapper->readPRG(0xd000) == NESTest::prg_bank_marker(3));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(2));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0xd000) == NESTest::prg_bank_marker(3));
 
     mapper->writeCHR(0x0456, 0x3c);
     REQUIRE(mapper->readCHR(0x0456) == 0x3c);
+    REQUIRE(NESTest::direct_chr_read(*mapper, 0x0456) == 0x3c);
 
     mapper->writePRG(0x8000, 0x05);
     REQUIRE(mapper->readPRG(0x9000) == NESTest::prg_bank_marker(1));
+    REQUIRE(NESTest::direct_prg_read(*mapper, 0x9000) == NESTest::prg_bank_marker(1));
 }
 
 TEST_CASE(
@@ -57,4 +63,7 @@ TEST_CASE(
     REQUIRE(restored.readPRG(0x9000) == NESTest::prg_bank_marker(2));
     REQUIRE(restored.readPRG(0xd000) == NESTest::prg_bank_marker(3));
     REQUIRE(restored.readCHR(0x0456) == 0x3c);
+    REQUIRE(NESTest::direct_prg_read(restored, 0x9000) == NESTest::prg_bank_marker(2));
+    REQUIRE(NESTest::direct_prg_read(restored, 0xd000) == NESTest::prg_bank_marker(3));
+    REQUIRE(NESTest::direct_chr_read(restored, 0x0456) == 0x3c);
 }

--- a/nes_emu/test/nes_emu/support/emulator_inspector.hpp
+++ b/nes_emu/test/nes_emu/support/emulator_inspector.hpp
@@ -16,6 +16,30 @@ struct EmulatorInspector {
     static Mapper& mapper(Emulator& emulator) {
         return *emulator.mapper;
     }
+
+    static bool uses_instruction_batching(Emulator& emulator) {
+        return emulator.can_batch_cpu_instructions();
+    }
+
+    static void step_cycle_by_cycle(Emulator& emulator) {
+        emulator.step_cycle_by_cycle();
+    }
+
+    static void step_instruction_batched(Emulator& emulator) {
+        emulator.step_instruction_batched();
+    }
+
+    static CPU::Snapshot cpu_snapshot(const Emulator& emulator) {
+        return emulator.cpu.save_state();
+    }
+
+    static MainBus::State bus_state(const Emulator& emulator) {
+        return emulator.bus.save_state();
+    }
+
+    static PPU::Snapshot ppu_snapshot(const Emulator& emulator) {
+        return emulator.ppu.save_state();
+    }
 };
 
 }  // namespace NES

--- a/nes_emu/test/nes_emu/support/mapper_test_helpers.hpp
+++ b/nes_emu/test/nes_emu/support/mapper_test_helpers.hpp
@@ -29,6 +29,30 @@ inline void write_mmc1_register(
         mapper.writePRG(address, static_cast<NES::NES_Byte>((value >> bit) & 1));
 }
 
+inline NES::NES_Byte direct_prg_read(
+    NES::Mapper& mapper,
+    NES::NES_Address address
+) {
+    NES::NES_Address page_base = static_cast<NES::NES_Address>(
+        0x8000 + (((address - 0x8000) / 0x2000) * 0x2000)
+    );
+    const NES::NES_Byte* page = mapper.getDirectPRGReadPage(page_base);
+    REQUIRE(page != nullptr);
+    return page[address & 0x1fff];
+}
+
+inline NES::NES_Byte direct_chr_read(
+    NES::Mapper& mapper,
+    NES::NES_Address address
+) {
+    NES::NES_Address page_base = static_cast<NES::NES_Address>(
+        (address / 0x0400) * 0x0400
+    );
+    const NES::NES_Byte* page = mapper.getDirectCHRReadPage(page_base);
+    REQUIRE(page != nullptr);
+    return page[address & 0x03ff];
+}
+
 }  // namespace NESTest
 
 #endif  // NES_EMU_TEST_SUPPORT_MAPPER_TEST_HELPERS_HPP

--- a/nes_emu/test/nes_emu/support/synthetic_rom.hpp
+++ b/nes_emu/test/nes_emu/support/synthetic_rom.hpp
@@ -8,11 +8,13 @@
 #ifndef NES_EMU_TEST_SUPPORT_SYNTHETIC_ROM_HPP
 #define NES_EMU_TEST_SUPPORT_SYNTHETIC_ROM_HPP
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <initializer_list>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -106,7 +108,8 @@ class TemporaryROM {
         const std::string& mirroring = "horizontal",
         bool chr_4k_markers = false,
         bool prg_8k_markers = false,
-        bool chr_1k_markers = false
+        bool chr_1k_markers = false,
+        std::initializer_list<NES::NES_Byte> reset_program = {}
     ) : path(temporary_path(name)) {
         std::vector<NES::NES_Byte> bytes = ines_header(
             mapper,
@@ -153,6 +156,16 @@ class TemporaryROM {
                 prg[reset_offset + 1] = 0x4c;
                 prg[reset_offset + 2] = 0x00;
                 prg[reset_offset + 3] = reset_high;
+            }
+            if (
+                reset_program.size() > 0 &&
+                reset_offset + reset_program.size() <= prg.size()
+            ) {
+                std::copy(
+                    reset_program.begin(),
+                    reset_program.end(),
+                    prg.begin() + reset_offset
+                );
             }
         }
         bytes.insert(bytes.end(), prg.begin(), prg.end());

--- a/nes_emu/test/nes_emu/support/test_mappers.hpp
+++ b/nes_emu/test/nes_emu/support/test_mappers.hpp
@@ -106,6 +106,8 @@ class ProgramTestMapper : public NES::Mapper {
     inline void writeCHR(NES::NES_Address address, NES::NES_Byte value) {
         chr[address & 0x1fff] = value;
     }
+
+    inline bool allowsSpriteRowPrefetch() const { return true; }
 };
 
 inline void run_cpu_cycles(NES::CPU& cpu, NES::MainBus& bus, int cycles) {
@@ -440,6 +442,8 @@ class PictureBusTestMapper : public NES::Mapper {
     inline void writeCHR(NES::NES_Address address, NES::NES_Byte value) {
         chr[address & 0x1fff] = value;
     }
+
+    inline bool allowsSpriteRowPrefetch() const { return true; }
 };
 
 }  // namespace NESTest

--- a/nes_emu/test/nes_emu/support/test_mappers.hpp
+++ b/nes_emu/test/nes_emu/support/test_mappers.hpp
@@ -193,6 +193,73 @@ class CPUCycleHookMapper : public NES::Mapper {
     inline bool observesCPUCycles() const { return true; }
 };
 
+class DirectReadTestMapper : public NES::Mapper {
+ private:
+    std::vector<NES::NES_Byte> prg;
+    std::vector<NES::NES_Byte> chr;
+    NES::NES_Byte prg_read_fallback;
+    NES::NES_Byte chr_read_fallback;
+    std::size_t active_prg_page;
+    std::size_t active_chr_page;
+
+ public:
+    DirectReadTestMapper() :
+        NES::Mapper(nullptr),
+        prg(0x10000, 0),
+        chr(0x4000, 0),
+        prg_read_fallback(0x11),
+        chr_read_fallback(0x22),
+        active_prg_page(0),
+        active_chr_page(0) {
+        fill_bank_markers(prg, 0x2000, 0x80);
+        fill_bank_markers(chr, 0x0400, 0x40);
+    }
+
+    inline std::unique_ptr<NES::Mapper> clone() const {
+        return std::unique_ptr<NES::Mapper>(new DirectReadTestMapper(*this));
+    }
+
+    inline NES::NES_Byte readPRG(NES::NES_Address address) {
+        (void) address;
+        return prg_read_fallback;
+    }
+
+    inline const NES::NES_Byte* getDirectPRGReadPage(
+        NES::NES_Address page_base
+    ) {
+        const std::size_t page = (page_base - 0x8000) / 0x2000;
+        if (page == 0)
+            return &prg[active_prg_page * 0x2000];
+        return &prg[page * 0x2000];
+    }
+
+    inline void writePRG(NES::NES_Address address, NES::NES_Byte value) {
+        (void) address;
+        active_prg_page = 4;
+        active_chr_page = 8;
+        prg[active_prg_page * 0x2000] = value;
+        chr[active_chr_page * 0x0400] = value;
+    }
+
+    inline NES::NES_Byte readCHR(NES::NES_Address address) {
+        (void) address;
+        return chr_read_fallback;
+    }
+
+    inline const NES::NES_Byte* getDirectCHRReadPage(
+        NES::NES_Address page_base
+    ) {
+        const std::size_t page = page_base / 0x0400;
+        if (page == 0)
+            return &chr[active_chr_page * 0x0400];
+        return &chr[page * 0x0400];
+    }
+
+    inline void writeCHR(NES::NES_Address address, NES::NES_Byte value) {
+        chr[address & 0x1fff] = value;
+    }
+};
+
 class PPUHookMapper : public NES::Mapper {
  public:
     int address_observations;
@@ -258,6 +325,27 @@ class PPUHookMapper : public NES::Mapper {
     }
 
     inline bool observesPPUWrites() const { return true; }
+};
+
+class DirectReadPPUHookMapper : public DirectReadTestMapper {
+ public:
+    int read_observations;
+
+    DirectReadPPUHookMapper() : DirectReadTestMapper(), read_observations(0) { }
+
+    inline std::unique_ptr<NES::Mapper> clone() const {
+        return std::unique_ptr<NES::Mapper>(
+            new DirectReadPPUHookMapper(*this)
+        );
+    }
+
+    inline void onPPURead(NES::NES_Address address, NES::NES_Byte value) {
+        (void) address;
+        (void) value;
+        ++read_observations;
+    }
+
+    inline bool observesPPUReads() const { return true; }
 };
 
 class ExpansionTestMapper : public NES::Mapper {

--- a/nes_emu/test/nes_emu/test_cpu.cpp
+++ b/nes_emu/test/nes_emu/test_cpu.cpp
@@ -10,6 +10,13 @@
 
 namespace {
 
+int run_ready_instruction(NES::CPU& cpu, NES::MainBus& bus) {
+    REQUIRE(cpu.can_execute_instruction());
+    int cycles = cpu.execute_instruction(bus);
+    cpu.consume_pending_cycles(cycles - 1);
+    return cycles;
+}
+
 bool reset_vector_starts_program_counter() {
     NESTest::ProgramTestMapper mapper;
     NES::MainBus bus;
@@ -91,6 +98,148 @@ bool addressing_modes_resolve_expected_memory() {
         bus.read(0x0022) == 0x99 &&
         bus.read(0x0023) == 0xaa &&
         bus.read(0x0026) == 0xbb
+    );
+}
+
+bool instruction_api_reports_representative_cycle_counts() {
+    NESTest::ProgramTestMapper mapper;
+    NES::MainBus bus;
+    NES::CPU cpu;
+    bus.write(0x0010, 0x33);
+    bus.write(0x0200, 0x44);
+    bus.write(0x0201, 0x55);
+    mapper.load(0x8000, {
+        0xa2, 0x01,       // LDX #$01 -> 2
+        0xa9, 0x7f,       // LDA #$7f -> 2
+        0x85, 0x10,       // STA $10 -> 3
+        0xbd, 0xff, 0x01, // LDA $01ff,X -> page cross -> 5
+        0xbd, 0x00, 0x02, // LDA $0200,X -> no page cross -> 4
+        0xf0, 0x01,       // BEQ not taken -> 2
+        0xea,             // NOP -> 2
+        0xa9, 0x00,       // LDA #$00 -> 2
+        0xf0, 0x01,       // BEQ taken same page -> 3
+        0xea,             // skipped NOP
+        0x48,             // PHA -> 3
+        0x68,             // PLA -> 4
+        0x20, 0x20, 0x80, // JSR $8020 -> 6
+        0x4c, 0x1c, 0x80  // JMP end -> 3
+    });
+    mapper.load(0x8020, {
+        0x60              // RTS -> 6
+    });
+    bus.set_mapper(&mapper);
+    cpu.reset(bus);
+
+    return (
+        run_ready_instruction(cpu, bus) == 2 &&
+        run_ready_instruction(cpu, bus) == 2 &&
+        run_ready_instruction(cpu, bus) == 3 &&
+        run_ready_instruction(cpu, bus) == 5 &&
+        run_ready_instruction(cpu, bus) == 4 &&
+        run_ready_instruction(cpu, bus) == 2 &&
+        run_ready_instruction(cpu, bus) == 2 &&
+        run_ready_instruction(cpu, bus) == 2 &&
+        run_ready_instruction(cpu, bus) == 3 &&
+        run_ready_instruction(cpu, bus) == 3 &&
+        run_ready_instruction(cpu, bus) == 4 &&
+        run_ready_instruction(cpu, bus) == 6 &&
+        run_ready_instruction(cpu, bus) == 6 &&
+        bus.read(0x0010) == 0x7f
+    );
+}
+
+bool instruction_api_reports_branch_page_cross_penalty() {
+    NESTest::ProgramTestMapper mapper;
+    NES::MainBus bus;
+    NES::CPU cpu;
+    mapper.setResetVector(0x80fa);
+    mapper.load(0x80fa, {
+        0xa9, 0x00,       // LDA #$00 -> set Z
+        0xf0, 0x05,       // BEQ $8103, crossing $80xx to $81xx
+        0xea,
+        0xea,
+        0xea,
+        0xea,
+        0xea
+    });
+    mapper.load(0x8103, {
+        0xa9, 0x01        // LDA #$01
+    });
+    bus.set_mapper(&mapper);
+    cpu.reset(bus);
+
+    return (
+        run_ready_instruction(cpu, bus) == 2 &&
+        run_ready_instruction(cpu, bus) == 5 &&
+        run_ready_instruction(cpu, bus) == 2
+    );
+}
+
+bool instruction_api_consumes_interrupt_entry_stalls() {
+    NESTest::IRQTestMapper mapper;
+    NES::MainBus bus;
+    NES::CPU cpu;
+    bus.set_mapper(&mapper);
+    mapper.setIRQCallback([&]() {
+        cpu.interrupt(bus, NES::CPU::IRQ_INTERRUPT);
+    });
+    cpu.reset(bus);
+    REQUIRE(run_ready_instruction(cpu, bus) == 2);  // CLI
+
+    mapper.triggerIRQ();
+    int stall_cycles = 0;
+    while (!cpu.can_execute_instruction())
+        stall_cycles += cpu.execute_instruction(bus);
+
+    int handler_cycles = run_ready_instruction(cpu, bus);
+    int store_cycles = run_ready_instruction(cpu, bus);
+    return (
+        stall_cycles == 7 &&
+        handler_cycles == 2 &&
+        store_cycles == 3 &&
+        bus.read(0x0002) == 0x42
+    );
+}
+
+bool instruction_api_reports_dma_stalls() {
+    NESTest::ProgramTestMapper mapper;
+    NES::MainBus bus;
+    NES::PictureBus picture_bus;
+    NES::PPU ppu;
+    NES::CPU cpu;
+    NES::Controller controllers[2];
+    mapper.load(0x8000, {
+        0xa9, 0x02,       // LDA #$02
+        0x8d, 0x14, 0x40, // STA $4014
+        0xa9, 0x55,       // LDA #$55
+        0x85, 0x06        // STA $06
+    });
+    bus.set_mapper(&mapper);
+    picture_bus.set_mapper(&mapper);
+    ppu.reset();
+    bus.connect_devices(&cpu, &ppu, &picture_bus, controllers);
+    bus.write(0x0200, 0xcc);
+    cpu.reset(bus);
+
+    REQUIRE(run_ready_instruction(cpu, bus) == 2);
+    int dma_instruction_cycles = cpu.execute_instruction(bus);
+    bool has_dma_stall = dma_instruction_cycles == 518;
+    cpu.consume_pending_cycles(40);
+    bool still_stalled = !cpu.can_execute_instruction();
+    cpu.consume_pending_cycles(dma_instruction_cycles - 1 - 40);
+    bool ready_after_dma = cpu.can_execute_instruction();
+    int load_cycles = run_ready_instruction(cpu, bus);
+    int store_cycles = run_ready_instruction(cpu, bus);
+    bus.write(NES::OAMADDR, 0x00);
+
+    return (
+        has_dma_stall &&
+        still_stalled &&
+        ready_after_dma &&
+        load_cycles == 2 &&
+        store_cycles == 3 &&
+        bus.read(0x0006) == 0x55 &&
+        bus.read(NES::OAMDATA) == 0xcc
     );
 }
 
@@ -221,4 +370,14 @@ TEST_CASE("CPU reset, addressing, interrupts, and flags are stable", "[cpu]") {
     REQUIRE(mapper_irq_enters_interrupt_handler());
     REQUIRE(oam_dma_stalls_cpu_before_next_instruction());
     REQUIRE(status_flags_match_zero_negative_overflow_and_carry_behavior());
+}
+
+TEST_CASE(
+    "CPU instruction-level API reports cycles and preserves stalls",
+    "[cpu][batching]"
+) {
+    REQUIRE(instruction_api_reports_representative_cycle_counts());
+    REQUIRE(instruction_api_reports_branch_page_cross_penalty());
+    REQUIRE(instruction_api_consumes_interrupt_entry_stalls());
+    REQUIRE(instruction_api_reports_dma_stalls());
 }

--- a/nes_emu/test/nes_emu/test_emulator_instruction_batching.cpp
+++ b/nes_emu/test/nes_emu/test_emulator_instruction_batching.cpp
@@ -1,0 +1,234 @@
+//  Program:      nes-py
+//  File:         test_emulator_instruction_batching.cpp
+//  Description:  Catch2 frame-level CPU instruction batching coverage
+//
+//  Copyright (c) 2019 Christian Kauten. All rights reserved.
+//
+
+#include <catch2/catch_test_macros.hpp>
+#include <fstream>
+#include <string>
+#include <vector>
+#include "nes_emu/emulator.hpp"
+#include "nes_emu/test/nes_emu/support/emulator_inspector.hpp"
+
+namespace {
+
+std::string game_path(const std::string& filename) {
+    return "nes_py/tests/games/" + filename;
+}
+
+bool file_exists(const std::string& path) {
+    std::ifstream stream(path.c_str(), std::ios::binary);
+    return stream.good();
+}
+
+bool cpu_snapshots_equal(
+    const NES::CPU::Snapshot& a,
+    const NES::CPU::Snapshot& b
+) {
+    return (
+        a.register_PC == b.register_PC &&
+        a.register_SP == b.register_SP &&
+        a.register_A == b.register_A &&
+        a.register_X == b.register_X &&
+        a.register_Y == b.register_Y &&
+        a.flags == b.flags &&
+        a.skip_cycles == b.skip_cycles &&
+        a.cycles == b.cycles
+    );
+}
+
+bool ppu_snapshots_equal(
+    const NES::PPU::Snapshot& a,
+    const NES::PPU::Snapshot& b
+) {
+    return (
+        a.sprite_memory == b.sprite_memory &&
+        a.scanline_sprites == b.scanline_sprites &&
+        a.scanline_sprite_count == b.scanline_sprite_count &&
+        a.scanline_sprite_rows_cached == b.scanline_sprite_rows_cached &&
+        a.scanline_sprite_rows_generation == b.scanline_sprite_rows_generation &&
+        a.pipeline_state == b.pipeline_state &&
+        a.cycles == b.cycles &&
+        a.scanline == b.scanline &&
+        a.is_even_frame == b.is_even_frame &&
+        a.is_vblank == b.is_vblank &&
+        a.is_sprite_zero_hit == b.is_sprite_zero_hit &&
+        a.data_address == b.data_address &&
+        a.temp_address == b.temp_address &&
+        a.fine_x_scroll == b.fine_x_scroll &&
+        a.is_first_write == b.is_first_write &&
+        a.data_buffer == b.data_buffer &&
+        a.sprite_data_address == b.sprite_data_address &&
+        a.is_showing_sprites == b.is_showing_sprites &&
+        a.is_showing_background == b.is_showing_background &&
+        a.is_hiding_edge_sprites == b.is_hiding_edge_sprites &&
+        a.is_hiding_edge_background == b.is_hiding_edge_background &&
+        a.is_long_sprites == b.is_long_sprites &&
+        a.is_interrupting == b.is_interrupting &&
+        a.background_page == b.background_page &&
+        a.sprite_page == b.sprite_page &&
+        a.data_address_increment == b.data_address_increment &&
+        a.background_tile_cache_valid == b.background_tile_cache_valid &&
+        a.background_tile_cache_address == b.background_tile_cache_address &&
+        a.background_tile_cache_page == b.background_tile_cache_page &&
+        a.background_tile_cache_generation == b.background_tile_cache_generation &&
+        a.background_tile_cache_low == b.background_tile_cache_low &&
+        a.background_tile_cache_high == b.background_tile_cache_high &&
+        a.background_tile_cache_attribute == b.background_tile_cache_attribute &&
+        a.background_tile_cache_low_bits == b.background_tile_cache_low_bits &&
+        a.background_tile_cache_high_bits == b.background_tile_cache_high_bits &&
+        a.background_tile_cache_palette_high ==
+            b.background_tile_cache_palette_high &&
+        a.background_tile_cache_opaque_mask ==
+            b.background_tile_cache_opaque_mask &&
+        a.screen == b.screen
+    );
+}
+
+void require_emulator_states_equal(
+    NES::Emulator& cycle_emulator,
+    NES::Emulator& batched_emulator,
+    const std::string& phase
+) {
+    INFO(phase);
+    REQUIRE(cpu_snapshots_equal(
+        NES::EmulatorInspector::cpu_snapshot(cycle_emulator),
+        NES::EmulatorInspector::cpu_snapshot(batched_emulator)
+    ));
+    REQUIRE(
+        NES::EmulatorInspector::bus_state(cycle_emulator).ram ==
+        NES::EmulatorInspector::bus_state(batched_emulator).ram
+    );
+    REQUIRE(ppu_snapshots_equal(
+        NES::EmulatorInspector::ppu_snapshot(cycle_emulator),
+        NES::EmulatorInspector::ppu_snapshot(batched_emulator)
+    ));
+}
+
+void compare_cycle_and_batched_frames(
+    const std::string& path,
+    int expected_mapper
+) {
+    REQUIRE(file_exists(path));
+    NES::Emulator cycle_emulator(path);
+    NES::Emulator batched_emulator(path);
+    REQUIRE(cycle_emulator.get_mapper_number() == expected_mapper);
+    REQUIRE(batched_emulator.get_mapper_number() == expected_mapper);
+    REQUIRE(NES::EmulatorInspector::uses_instruction_batching(batched_emulator));
+
+    cycle_emulator.reset();
+    batched_emulator.reset();
+    require_emulator_states_equal(
+        cycle_emulator,
+        batched_emulator,
+        path + " after reset"
+    );
+
+    for (int frame = 0; frame < 3; ++frame) {
+        NES::EmulatorInspector::step_cycle_by_cycle(cycle_emulator);
+        NES::EmulatorInspector::step_instruction_batched(batched_emulator);
+        require_emulator_states_equal(
+            cycle_emulator,
+            batched_emulator,
+            path + " frame " + std::to_string(frame)
+        );
+    }
+
+    cycle_emulator.backup();
+    batched_emulator.backup();
+    NES::EmulatorInspector::step_cycle_by_cycle(cycle_emulator);
+    NES::EmulatorInspector::step_instruction_batched(batched_emulator);
+    require_emulator_states_equal(
+        cycle_emulator,
+        batched_emulator,
+        path + " after backup continuation"
+    );
+
+    NES::EmulatorInspector::step_cycle_by_cycle(cycle_emulator);
+    NES::EmulatorInspector::step_instruction_batched(batched_emulator);
+    require_emulator_states_equal(
+        cycle_emulator,
+        batched_emulator,
+        path + " after second continuation"
+    );
+
+    cycle_emulator.restore();
+    batched_emulator.restore();
+    require_emulator_states_equal(
+        cycle_emulator,
+        batched_emulator,
+        path + " after restore"
+    );
+
+    NES::EmulatorInspector::step_cycle_by_cycle(cycle_emulator);
+    NES::EmulatorInspector::step_instruction_batched(batched_emulator);
+    require_emulator_states_equal(
+        cycle_emulator,
+        batched_emulator,
+        path + " after restored continuation"
+    );
+}
+
+void compare_default_and_cycle_path_for_hooked_mapper(
+    const std::string& path,
+    int expected_mapper
+) {
+    REQUIRE(file_exists(path));
+    NES::Emulator cycle_emulator(path);
+    NES::Emulator default_emulator(path);
+    REQUIRE(cycle_emulator.get_mapper_number() == expected_mapper);
+    REQUIRE(default_emulator.get_mapper_number() == expected_mapper);
+    REQUIRE_FALSE(NES::EmulatorInspector::uses_instruction_batching(
+        default_emulator
+    ));
+
+    cycle_emulator.reset();
+    default_emulator.reset();
+    NES::EmulatorInspector::step_cycle_by_cycle(cycle_emulator);
+    default_emulator.step();
+    require_emulator_states_equal(
+        cycle_emulator,
+        default_emulator,
+        path + " hooked mapper default step"
+    );
+}
+
+}  // namespace
+
+TEST_CASE(
+    "instruction-batched stepping matches cycle-by-cycle frames",
+    "[emulator][batching]"
+) {
+    compare_cycle_and_batched_frames(
+        game_path("super-mario-bros-1.nes"),
+        0
+    );
+    compare_cycle_and_batched_frames(
+        game_path("the-legend-of-zelda.nes"),
+        1
+    );
+    compare_cycle_and_batched_frames(
+        game_path("mega-man.nes"),
+        2
+    );
+    compare_cycle_and_batched_frames(
+        game_path("adventure-island.nes"),
+        3
+    );
+}
+
+TEST_CASE(
+    "CPU-cycle-hooked mappers keep the cycle-by-cycle frame path",
+    "[emulator][batching][mapper]"
+) {
+    compare_default_and_cycle_path_for_hooked_mapper(
+        game_path("castlevania-iii-draculas-curse.nes"),
+        5
+    );
+    compare_default_and_cycle_path_for_hooked_mapper(
+        game_path("batman-return-of-the-joker.nes"),
+        69
+    );
+}

--- a/nes_emu/test/nes_emu/test_main_bus.cpp
+++ b/nes_emu/test/nes_emu/test_main_bus.cpp
@@ -97,6 +97,22 @@ bool prg_rom_routes_through_mapper() {
     );
 }
 
+bool prg_rom_prefers_direct_read_pages_and_refreshes_after_writes() {
+    NESTest::DirectReadTestMapper mapper;
+    NES::MainBus bus;
+    bus.set_mapper(&mapper);
+
+    bool initial_direct = (
+        bus.read(0x8000) == 0x80 &&
+        bus.read(0xa000) == 0x81 &&
+        bus.read(0xc000) == 0x82 &&
+        bus.read(0xe000) == 0x83
+    );
+
+    bus.write(0x9000, 0x5a);
+    return initial_direct && bus.read(0x8000) == 0x5a;
+}
+
 }  // namespace
 
 TEST_CASE("main bus mirrors RAM and routes devices through fixed paths", "[bus]") {
@@ -107,4 +123,5 @@ TEST_CASE("main bus mirrors RAM and routes devices through fixed paths", "[bus]"
     REQUIRE(expansion_area_uses_mapper_when_present());
     REQUIRE(prg_ram_routes_through_mapper());
     REQUIRE(prg_rom_routes_through_mapper());
+    REQUIRE(prg_rom_prefers_direct_read_pages_and_refreshes_after_writes());
 }

--- a/nes_emu/test/nes_emu/test_picture_bus.cpp
+++ b/nes_emu/test/nes_emu/test_picture_bus.cpp
@@ -24,6 +24,37 @@ bool pattern_table_addresses_route_to_mapper_chr() {
     );
 }
 
+bool pattern_table_reads_use_direct_pages_when_available() {
+    NESTest::DirectReadTestMapper mapper;
+    NES::PictureBus bus;
+    bus.set_mapper(&mapper);
+    return (
+        bus.read(0x0000) == 0x40 &&
+        bus.read(0x0400) == 0x41 &&
+        bus.read(0x1c00) == 0x47
+    );
+}
+
+bool mapper_ppu_read_hooks_disable_direct_chr_pages() {
+    NESTest::DirectReadPPUHookMapper mapper;
+    NES::PictureBus bus;
+    bus.set_mapper(&mapper);
+    return bus.read(0x0000) == 0x22 && mapper.read_observations == 1;
+}
+
+bool cpu_mapper_writes_refresh_picture_bus_direct_pages() {
+    NESTest::DirectReadTestMapper mapper;
+    NES::MainBus main_bus;
+    NES::PictureBus picture_bus;
+    main_bus.set_mapper(&mapper);
+    picture_bus.set_mapper(&mapper);
+    main_bus.connect_devices(nullptr, nullptr, &picture_bus, nullptr);
+
+    bool initial_direct = picture_bus.read(0x0000) == 0x40;
+    main_bus.write(0x9000, 0x6e);
+    return initial_direct && picture_bus.read(0x0000) == 0x6e;
+}
+
 bool vertical_nametable_mirroring_matches_address_aliases() {
     NESTest::PictureBusTestMapper mapper(NES::VERTICAL);
     NES::PictureBus bus;
@@ -175,6 +206,9 @@ bool ppu_render_pipeline_emits_expected_mapper_hook_sequence() {
 
 TEST_CASE("picture bus and PPU addressing behavior is stable", "[ppu]") {
     REQUIRE(pattern_table_addresses_route_to_mapper_chr());
+    REQUIRE(pattern_table_reads_use_direct_pages_when_available());
+    REQUIRE(mapper_ppu_read_hooks_disable_direct_chr_pages());
+    REQUIRE(cpu_mapper_writes_refresh_picture_bus_direct_pages());
     REQUIRE(vertical_nametable_mirroring_matches_address_aliases());
     REQUIRE(four_screen_mirroring_keeps_all_tables_separate());
     REQUIRE(one_screen_mirroring_selects_lower_and_higher_pages());

--- a/nes_emu/test/nes_emu/test_ppu_background_tile_rows.cpp
+++ b/nes_emu/test/nes_emu/test_ppu_background_tile_rows.cpp
@@ -1,0 +1,224 @@
+//  Program:      nes-py
+//  File:         test_ppu_background_tile_rows.cpp
+//  Description:  Catch2 coverage for decoded background tile-row batching
+//
+//  Copyright (c) 2019 Christian Kauten. All rights reserved.
+//
+
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+#include "nes_emu/palette.hpp"
+#include "nes_emu/picture_bus.hpp"
+#include "nes_emu/ppu.hpp"
+#include "nes_emu/test/nes_emu/support/test_mappers.hpp"
+
+namespace {
+
+const int PRE_RENDER_CYCLES = 342;
+const int RENDER_SCANLINE_CYCLES = NES::SCANLINE_END_CYCLE;
+
+void run_cycles(NES::PPU& ppu, NES::PictureBus& bus, int cycles) {
+    for (int cycle = 0; cycle < cycles; ++cycle)
+        ppu.cycle(bus);
+}
+
+void hide_all_sprites(NES::PPU& ppu) {
+    ppu.set_OAM_address(0);
+    for (int index = 0; index < 64; ++index) {
+        ppu.set_OAM_data(0xff);
+        ppu.set_OAM_data(0x00);
+        ppu.set_OAM_data(0x00);
+        ppu.set_OAM_data(0x00);
+    }
+    ppu.set_OAM_address(0);
+}
+
+void seed_palette(NES::PictureBus& bus) {
+    for (NES::NES_Address index = 0; index < 0x10; ++index)
+        bus.write(
+            static_cast<NES::NES_Address>(0x3f00 + index),
+            static_cast<NES::NES_Byte>(index)
+        );
+}
+
+void set_tile_row(
+    NES::PictureBus& bus,
+    NES::NES_Byte tile,
+    NES::NES_Byte fine_y,
+    NES::NES_Byte low,
+    NES::NES_Byte high
+) {
+    const NES::NES_Address address = static_cast<NES::NES_Address>(
+        tile * 16 + fine_y
+    );
+    bus.write(address, low);
+    bus.write(static_cast<NES::NES_Address>(address + 8), high);
+}
+
+NES::NES_Pixel screen_pixel(NES::PPU& ppu, int y, int x) {
+    return ppu.get_screen_buffer()[y * NES::SCANLINE_VISIBLE_DOTS + x];
+}
+
+void prepare_scrolled_background(
+    NES::PPU& ppu,
+    NES::NES_Byte mask,
+    NES::NES_Byte horizontal_scroll,
+    NES::NES_Byte vertical_scroll
+) {
+    hide_all_sprites(ppu);
+    ppu.set_scroll(horizontal_scroll);
+    ppu.set_scroll(vertical_scroll);
+    ppu.set_mask(mask);
+}
+
+}  // namespace
+
+TEST_CASE(
+    "background tile row batching preserves fine X scroll",
+    "[ppu][background]"
+) {
+    NESTest::PictureBusTestMapper mapper(NES::VERTICAL);
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    seed_palette(bus);
+    prepare_scrolled_background(ppu, 0x0a, 0x03, 0x00);
+    bus.write(0x2000, 0x00);
+    bus.write(0x2001, 0x01);
+    set_tile_row(bus, 0x00, 0, 0x10, 0x00);
+    set_tile_row(bus, 0x01, 0, 0x80, 0x00);
+
+    run_cycles(ppu, bus, PRE_RENDER_CYCLES + 6);
+
+    REQUIRE(screen_pixel(ppu, 0, 0) == NES::PALETTE[0x01]);
+    REQUIRE(screen_pixel(ppu, 0, 1) == NES::PALETTE[0x00]);
+    REQUIRE(screen_pixel(ppu, 0, 5) == NES::PALETTE[0x01]);
+}
+
+TEST_CASE(
+    "background tile row batching wraps coarse X across nametables",
+    "[ppu][background]"
+) {
+    NESTest::PictureBusTestMapper mapper(NES::VERTICAL);
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    seed_palette(bus);
+    prepare_scrolled_background(ppu, 0x1e, 0xf8, 0x00);
+    bus.write(0x201f, 0x02);
+    bus.write(0x2400, 0x03);
+    set_tile_row(bus, 0x02, 0, 0xff, 0x00);
+    set_tile_row(bus, 0x03, 0, 0x00, 0xff);
+
+    run_cycles(ppu, bus, PRE_RENDER_CYCLES + 9);
+
+    REQUIRE(screen_pixel(ppu, 0, 0) == NES::PALETTE[0x01]);
+    REQUIRE(screen_pixel(ppu, 0, 8) == NES::PALETTE[0x02]);
+}
+
+TEST_CASE(
+    "background tile row batching preserves vertical fine-Y increments",
+    "[ppu][background]"
+) {
+    NESTest::PictureBusTestMapper mapper(NES::VERTICAL);
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    seed_palette(bus);
+    prepare_scrolled_background(ppu, 0x1e, 0x00, 0x00);
+    bus.write(0x2000, 0x04);
+    set_tile_row(bus, 0x04, 0, 0x80, 0x00);
+    set_tile_row(bus, 0x04, 1, 0x00, 0x80);
+
+    run_cycles(
+        ppu,
+        bus,
+        PRE_RENDER_CYCLES + RENDER_SCANLINE_CYCLES + 1
+    );
+
+    REQUIRE(screen_pixel(ppu, 0, 0) == NES::PALETTE[0x01]);
+    REQUIRE(screen_pixel(ppu, 1, 0) == NES::PALETTE[0x02]);
+}
+
+TEST_CASE(
+    "background tile row batching preserves attribute quadrants",
+    "[ppu][background]"
+) {
+    NESTest::PictureBusTestMapper mapper(NES::VERTICAL);
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    seed_palette(bus);
+    prepare_scrolled_background(ppu, 0x1e, 0x00, 0x00);
+    bus.write(0x2000, 0x04);
+    bus.write(0x2002, 0x04);
+    bus.write(0x2040, 0x04);
+    bus.write(0x2042, 0x04);
+    bus.write(0x23c0, 0xe4);
+    set_tile_row(bus, 0x04, 0, 0x80, 0x00);
+
+    run_cycles(
+        ppu,
+        bus,
+        PRE_RENDER_CYCLES + RENDER_SCANLINE_CYCLES * 16 + 17
+    );
+
+    REQUIRE(screen_pixel(ppu, 0, 0) == NES::PALETTE[0x01]);
+    REQUIRE(screen_pixel(ppu, 0, 16) == NES::PALETTE[0x05]);
+    REQUIRE(screen_pixel(ppu, 16, 0) == NES::PALETTE[0x09]);
+    REQUIRE(screen_pixel(ppu, 16, 16) == NES::PALETTE[0x0d]);
+}
+
+TEST_CASE(
+    "background tile row batching preserves left-edge background masking",
+    "[ppu][background]"
+) {
+    NESTest::PictureBusTestMapper mapper(NES::VERTICAL);
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    seed_palette(bus);
+    prepare_scrolled_background(ppu, 0x18, 0x00, 0x00);
+    bus.write(0x2000, 0x00);
+    bus.write(0x2001, 0x04);
+    set_tile_row(bus, 0x04, 0, 0x80, 0x00);
+
+    run_cycles(ppu, bus, PRE_RENDER_CYCLES + 9);
+
+    REQUIRE(screen_pixel(ppu, 0, 0) == NES::PALETTE[0x00]);
+    REQUIRE(screen_pixel(ppu, 0, 7) == NES::PALETTE[0x00]);
+    REQUIRE(screen_pixel(ppu, 0, 8) == NES::PALETTE[0x01]);
+}
+
+TEST_CASE(
+    "background tile row batching is disabled for mapper PPU observers",
+    "[ppu][background][mapper]"
+) {
+    NESTest::PPUHookMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+    const std::vector<NES::NES_Address> expected = {
+        0x2000, 0x0000, 0x0008, 0x23c0,
+        0x2000, 0x0000, 0x0008, 0x23c0,
+    };
+
+    bus.set_mapper(&mapper);
+    REQUIRE(bus.has_mapper_ppu_observers());
+    ppu.reset();
+
+    run_cycles(ppu, bus, PRE_RENDER_CYCLES + 2);
+
+    REQUIRE(mapper.address_observations == 8);
+    REQUIRE(mapper.read_observations == 8);
+    REQUIRE(mapper.address_sequence == expected);
+}

--- a/nes_emu/test/nes_emu/test_ppu_background_tile_rows.cpp
+++ b/nes_emu/test/nes_emu/test_ppu_background_tile_rows.cpp
@@ -71,6 +71,28 @@ void prepare_scrolled_background(
     ppu.set_mask(mask);
 }
 
+class CacheablePPUAddressMapper : public NESTest::PictureBusTestMapper {
+ public:
+    int address_observations;
+    std::vector<NES::NES_Address> address_sequence;
+
+    CacheablePPUAddressMapper() :
+        NESTest::PictureBusTestMapper(NES::VERTICAL),
+        address_observations(0),
+        address_sequence() { }
+
+    inline void onPPUAddress(NES::NES_Address address) {
+        ++address_observations;
+        address_sequence.push_back(address);
+    }
+
+    inline bool observesPPUAddresses() const { return true; }
+
+    inline bool allowsBackgroundTileCacheWithPPUAddressObservations() const {
+        return true;
+    }
+};
+
 }  // namespace
 
 TEST_CASE(
@@ -220,5 +242,27 @@ TEST_CASE(
 
     REQUIRE(mapper.address_observations == 8);
     REQUIRE(mapper.read_observations == 8);
+    REQUIRE(mapper.address_sequence == expected);
+}
+
+TEST_CASE(
+    "background tile row batching can preserve mapper PPU address observations",
+    "[ppu][background][mapper]"
+) {
+    CacheablePPUAddressMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+    const std::vector<NES::NES_Address> expected = {
+        0x2000, 0x0000, 0x0008, 0x23c0,
+    };
+
+    bus.set_mapper(&mapper);
+    REQUIRE(bus.has_mapper_ppu_observers());
+    REQUIRE(bus.can_cache_background_tile_rows());
+    ppu.reset();
+
+    run_cycles(ppu, bus, PRE_RENDER_CYCLES + 2);
+
+    REQUIRE(mapper.address_observations == 4);
     REQUIRE(mapper.address_sequence == expected);
 }

--- a/nes_emu/test/nes_emu/test_ppu_sprite_prefetch.cpp
+++ b/nes_emu/test/nes_emu/test_ppu_sprite_prefetch.cpp
@@ -1,0 +1,228 @@
+//  Program:      nes-py
+//  File:         test_ppu_sprite_prefetch.cpp
+//  Description:  Catch2 coverage for PPU sprite row prefetching
+//
+//  Copyright (c) 2019 Christian Kauten. All rights reserved.
+//
+
+#include <catch2/catch_test_macros.hpp>
+#include "nes_emu/palette.hpp"
+#include "nes_emu/picture_bus.hpp"
+#include "nes_emu/ppu.hpp"
+#include "nes_emu/test/nes_emu/support/test_mappers.hpp"
+
+namespace {
+
+const int PRE_RENDER_CYCLES = 342;
+const int RENDER_SCANLINE_CYCLES = NES::SCANLINE_END_CYCLE;
+const int FIRST_SPRITE_SCANLINE_CYCLES =
+    PRE_RENDER_CYCLES + RENDER_SCANLINE_CYCLES;
+const int PPU_CYCLES_PER_FRAME = 29781 * 3;
+
+class CountingSpriteMapper : public NESTest::ProgramTestMapper {
+ public:
+    int chr_reads;
+
+    CountingSpriteMapper() : NESTest::ProgramTestMapper(), chr_reads(0) { }
+
+    inline NES::NES_Byte readCHR(NES::NES_Address address) {
+        ++chr_reads;
+        return NESTest::ProgramTestMapper::readCHR(address);
+    }
+};
+
+void run_cycles(NES::PPU& ppu, NES::PictureBus& bus, int cycles) {
+    for (int cycle = 0; cycle < cycles; ++cycle)
+        ppu.cycle(bus);
+}
+
+void hide_all_sprites(NES::PPU& ppu) {
+    ppu.set_OAM_address(0);
+    for (int index = 0; index < 64; ++index) {
+        ppu.set_OAM_data(0xff);
+        ppu.set_OAM_data(0x00);
+        ppu.set_OAM_data(0x00);
+        ppu.set_OAM_data(0x00);
+    }
+    ppu.set_OAM_address(0);
+}
+
+void write_sprite(
+    NES::PPU& ppu,
+    NES::NES_Byte index,
+    NES::NES_Byte y,
+    NES::NES_Byte tile,
+    NES::NES_Byte attribute,
+    NES::NES_Byte x
+) {
+    ppu.set_OAM_address(static_cast<NES::NES_Byte>(index * 4));
+    ppu.set_OAM_data(y);
+    ppu.set_OAM_data(tile);
+    ppu.set_OAM_data(attribute);
+    ppu.set_OAM_data(x);
+    ppu.set_OAM_address(0);
+}
+
+void seed_common_palette(NES::PictureBus& bus) {
+    bus.write(0x3f00, 0x00);
+    bus.write(0x3f01, 0x01);
+    bus.write(0x3f11, 0x21);
+    bus.write(0x3f15, 0x25);
+}
+
+void seed_opaque_background(NES::PictureBus& bus) {
+    for (NES::NES_Address row = 0; row < 8; ++row) {
+        bus.write(row, 0xff);
+        bus.write(static_cast<NES::NES_Address>(row + 8), 0x00);
+    }
+}
+
+NES::NES_Pixel screen_pixel(NES::PPU& ppu, int y, int x) {
+    return ppu.get_screen_buffer()[y * NES::SCANLINE_VISIBLE_DOTS + x];
+}
+
+}  // namespace
+
+TEST_CASE(
+    "sprite row prefetch reads each selected sprite row once",
+    "[ppu][sprite]"
+) {
+    CountingSpriteMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    REQUIRE(bus.can_prefetch_sprite_rows());
+    ppu.reset();
+    ppu.control(0x00);
+    ppu.set_mask(0x14);
+    hide_all_sprites(ppu);
+    seed_common_palette(bus);
+    bus.write(0x0010, 0xff);
+    bus.write(0x0018, 0x00);
+    for (NES::NES_Byte index = 0; index < 8; ++index)
+        write_sprite(
+            ppu,
+            index,
+            0x00,
+            0x01,
+            0x00,
+            static_cast<NES::NES_Byte>(index * 16)
+        );
+
+    mapper.chr_reads = 0;
+    run_cycles(ppu, bus, FIRST_SPRITE_SCANLINE_CYCLES);
+    REQUIRE(mapper.chr_reads == 16);
+
+    run_cycles(ppu, bus, 8);
+    REQUIRE(mapper.chr_reads == 16);
+    REQUIRE(screen_pixel(ppu, 1, 0) == NES::PALETTE[0x21]);
+    REQUIRE(screen_pixel(ppu, 1, 7) == NES::PALETTE[0x21]);
+}
+
+TEST_CASE(
+    "sprite row prefetch preserves flips, priority, transparency, and hit",
+    "[ppu][sprite]"
+) {
+    NESTest::ProgramTestMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    ppu.control(0x00);
+    ppu.set_mask(0x1e);
+    hide_all_sprites(ppu);
+    seed_common_palette(bus);
+    seed_opaque_background(bus);
+
+    mapper.writeCHR(0x0010, 0x80);
+    mapper.writeCHR(0x0018, 0x00);
+    mapper.writeCHR(0x0027, 0x80);
+    mapper.writeCHR(0x002f, 0x00);
+    mapper.writeCHR(0x0030, 0x80);
+    mapper.writeCHR(0x0038, 0x00);
+    mapper.writeCHR(0x0050, 0x80);
+    mapper.writeCHR(0x0058, 0x00);
+    mapper.writeCHR(0x0060, 0x80);
+    mapper.writeCHR(0x0068, 0x00);
+
+    write_sprite(ppu, 0, 0x00, 0x01, 0x40, 10);
+    write_sprite(ppu, 1, 0x00, 0x02, 0x80, 30);
+    write_sprite(ppu, 2, 0x00, 0x03, 0x20, 50);
+    write_sprite(ppu, 3, 0x00, 0x04, 0x00, 70);
+    write_sprite(ppu, 4, 0x00, 0x05, 0x00, 90);
+    write_sprite(ppu, 5, 0x00, 0x06, 0x01, 90);
+    write_sprite(ppu, 6, 0x00, 0x04, 0x00, 130);
+    write_sprite(ppu, 7, 0x00, 0x04, 0x00, 150);
+
+    run_cycles(ppu, bus, PPU_CYCLES_PER_FRAME);
+
+    REQUIRE(screen_pixel(ppu, 1, 10) == NES::PALETTE[0x01]);
+    REQUIRE(screen_pixel(ppu, 1, 17) == NES::PALETTE[0x21]);
+    REQUIRE(screen_pixel(ppu, 1, 30) == NES::PALETTE[0x21]);
+    REQUIRE(screen_pixel(ppu, 1, 50) == NES::PALETTE[0x01]);
+    REQUIRE(screen_pixel(ppu, 1, 70) == NES::PALETTE[0x01]);
+    REQUIRE(screen_pixel(ppu, 1, 90) == NES::PALETTE[0x21]);
+    REQUIRE((ppu.get_status() & 0x40) == 0x40);
+}
+
+TEST_CASE("sprite row prefetch preserves 8x16 sprite rows", "[ppu][sprite]") {
+    NESTest::ProgramTestMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    ppu.control(0x20);
+    ppu.set_mask(0x14);
+    hide_all_sprites(ppu);
+    seed_common_palette(bus);
+
+    mapper.writeCHR(0x1020, 0x80);
+    mapper.writeCHR(0x1028, 0x00);
+    mapper.writeCHR(0x1030, 0x80);
+    mapper.writeCHR(0x1038, 0x00);
+    for (NES::NES_Byte index = 0; index < 8; ++index)
+        write_sprite(
+            ppu,
+            index,
+            0x00,
+            0x03,
+            0x00,
+            static_cast<NES::NES_Byte>(12 + index * 24)
+        );
+
+    run_cycles(ppu, bus, PPU_CYCLES_PER_FRAME);
+
+    REQUIRE(screen_pixel(ppu, 1, 12) == NES::PALETTE[0x21]);
+    REQUIRE(screen_pixel(ppu, 9, 12) == NES::PALETTE[0x21]);
+}
+
+TEST_CASE(
+    "sprite row prefetch is disabled for mapper PPU observers",
+    "[ppu][sprite][mapper]"
+) {
+    NESTest::PPUHookMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    REQUIRE_FALSE(bus.can_prefetch_sprite_rows());
+    ppu.reset();
+    ppu.control(0x00);
+    ppu.set_mask(0x14);
+    hide_all_sprites(ppu);
+    write_sprite(ppu, 0, 0x00, 0x01, 0x00, 0x00);
+
+    run_cycles(ppu, bus, FIRST_SPRITE_SCANLINE_CYCLES);
+    REQUIRE(mapper.address_observations == 0);
+
+    run_cycles(ppu, bus, 2);
+    REQUIRE(mapper.address_observations == 4);
+    REQUIRE(mapper.read_observations == 4);
+    REQUIRE(mapper.address_sequence[0] == 0x0010);
+    REQUIRE(mapper.address_sequence[1] == 0x0018);
+    REQUIRE(mapper.address_sequence[2] == 0x0010);
+    REQUIRE(mapper.address_sequence[3] == 0x0018);
+}

--- a/nes_py/__init__.py
+++ b/nes_py/__init__.py
@@ -1,6 +1,7 @@
 """The nes-py NES emulator and Gymnasium environment package."""
 from .nes_env import NESEnv
+from .vector_env import VectorNESEmulator
 
 
 # explicitly define the outward facing API of this package
-__all__ = [NESEnv.__name__]
+__all__ = [NESEnv.__name__, VectorNESEmulator.__name__]

--- a/nes_py/_native.pyx
+++ b/nes_py/_native.pyx
@@ -105,6 +105,29 @@ cdef object _uint8_array(
     return array
 
 
+cdef cnp.ndarray _validated_uint8_output(object output, tuple shape):
+    """Return a writable C-contiguous uint8 output array for native copies."""
+    cdef cnp.ndarray array
+    cdef object actual_shape
+    if output is None:
+        return np.empty(shape, dtype=np.uint8)
+    array = np.asarray(output)
+    actual_shape = np.shape(array)
+    if actual_shape != shape:
+        raise ValueError(
+            'output shape must be {}, got {}'.format(shape, actual_shape)
+        )
+    if array.dtype != np.uint8:
+        raise TypeError(
+            'output dtype must be uint8, got {}'.format(array.dtype)
+        )
+    if not array.flags.c_contiguous:
+        raise ValueError('output must be C-contiguous')
+    if not array.flags.writeable:
+        raise ValueError('output must be writable')
+    return array
+
+
 cdef class NativeEmulator:
     """Python-owned wrapper around ``NES::Emulator``."""
 
@@ -151,6 +174,52 @@ cdef class NativeEmulator:
             data += 1
             strides[2] = 1
         return _uint8_array(3, dims, strides, <void*> data, self)
+
+    def copy_screen_rgb(self, object output=None):
+        """Copy the current screen to a C-contiguous 24-bit RGB array."""
+        self._require_open()
+        cdef cnp.ndarray array = _validated_uint8_output(
+            output,
+            (SCREEN_HEIGHT, SCREEN_WIDTH, 3),
+        )
+        cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
+        cdef NES_Pixel* source = self._emu.get_screen_buffer()
+        cdef size_t index
+        cdef size_t out_index
+        cdef size_t pixel_count = SCREEN_WIDTH * SCREEN_HEIGHT
+        cdef NES_Pixel pixel
+        with nogil:
+            for index in range(pixel_count):
+                pixel = source[index]
+                out_index = index * 3
+                out[out_index] = <uint8_t>((pixel >> 16) & 0xff)
+                out[out_index + 1] = <uint8_t>((pixel >> 8) & 0xff)
+                out[out_index + 2] = <uint8_t>(pixel & 0xff)
+        return array
+
+    def copy_screen_grayscale(self, object output=None):
+        """Copy the current screen to a C-contiguous 8-bit luma array."""
+        self._require_open()
+        cdef cnp.ndarray array = _validated_uint8_output(
+            output,
+            (SCREEN_HEIGHT, SCREEN_WIDTH),
+        )
+        cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
+        cdef NES_Pixel* source = self._emu.get_screen_buffer()
+        cdef size_t index
+        cdef size_t pixel_count = SCREEN_WIDTH * SCREEN_HEIGHT
+        cdef NES_Pixel pixel
+        cdef uint32_t r
+        cdef uint32_t g
+        cdef uint32_t b
+        with nogil:
+            for index in range(pixel_count):
+                pixel = source[index]
+                r = (pixel >> 16) & 0xff
+                g = (pixel >> 8) & 0xff
+                b = pixel & 0xff
+                out[index] = <uint8_t>((77 * r + 150 * g + 29 * b) >> 8)
+        return array
 
     def ram_buffer(self):
         """Return a no-copy view over the native internal RAM buffer."""

--- a/nes_py/_native.pyx
+++ b/nes_py/_native.pyx
@@ -9,6 +9,7 @@ import numpy as np
 cimport numpy as cnp
 from libc.stddef cimport size_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t
+from libc.stdlib cimport free, malloc
 from libcpp cimport bool as cpp_bool
 from libcpp.string cimport string
 
@@ -16,9 +17,24 @@ from libcpp.string cimport string
 cnp.import_array()
 
 
-SCREEN_WIDTH = 256
-SCREEN_HEIGHT = 240
-RAM_SIZE = 0x800
+cdef enum:
+    SCREEN_WIDTH_C = 256
+    SCREEN_HEIGHT_C = 240
+    RAM_SIZE_C = 0x800
+    RAM_READ_ENCODING_BYTE_CODE = 0
+    RAM_READ_ENCODING_LITTLE_CODE = 1
+    RAM_READ_ENCODING_BIG_CODE = 2
+    RAM_READ_ENCODING_BCD_CODE = 3
+    RAM_READ_ENCODING_DIGITS_CODE = 4
+
+SCREEN_WIDTH = SCREEN_WIDTH_C
+SCREEN_HEIGHT = SCREEN_HEIGHT_C
+RAM_SIZE = RAM_SIZE_C
+RAM_READ_ENCODING_BYTE = RAM_READ_ENCODING_BYTE_CODE
+RAM_READ_ENCODING_LITTLE = RAM_READ_ENCODING_LITTLE_CODE
+RAM_READ_ENCODING_BIG = RAM_READ_ENCODING_BIG_CODE
+RAM_READ_ENCODING_BCD = RAM_READ_ENCODING_BCD_CODE
+RAM_READ_ENCODING_DIGITS = RAM_READ_ENCODING_DIGITS_CODE
 
 
 cdef extern from "nes_emu/common.hpp" namespace "NES":
@@ -56,15 +72,23 @@ cdef extern from "nes_emu/cartridge.hpp" namespace "NES":
 
 
 cdef extern from "nes_emu/emulator.hpp" namespace "NES":
+    cdef cppclass EmulatorSnapshot "NES::Emulator::Snapshot":
+        EmulatorSnapshot() except +
+        EmulatorSnapshot(const EmulatorSnapshot&) except +
+
     cdef cppclass Emulator:
         Emulator(string rom_path) except +
-        NES_Pixel* get_screen_buffer()
-        NES_Byte* get_memory_buffer()
-        NES_Byte* get_controller(int port)
-        void reset() except +
+        NES_Pixel* get_screen_buffer() nogil
+        NES_Byte* get_memory_buffer() nogil
+        NES_Byte* get_controller(int port) nogil
+        void reset() except + nogil
         void step() except + nogil
         void backup() except +
         void restore() except +
+        EmulatorSnapshot save_state() except +
+        EmulatorSnapshot* create_snapshot() except +
+        void load_state(const EmulatorSnapshot& snapshot) except +
+        void load_snapshot(const EmulatorSnapshot* snapshot) except +
         int get_mapper_number()
         size_t get_prg_rom_size()
         size_t get_chr_rom_size()
@@ -128,6 +152,181 @@ cdef cnp.ndarray _validated_uint8_output(object output, tuple shape):
     return array
 
 
+cdef cnp.ndarray _validated_uint32_output(object output, tuple shape):
+    """Return a writable C-contiguous uint32 output array."""
+    cdef cnp.ndarray array
+    cdef object actual_shape
+    if output is None:
+        return np.empty(shape, dtype=np.uint32)
+    array = np.asarray(output)
+    actual_shape = np.shape(array)
+    if actual_shape != shape:
+        raise ValueError(
+            'output shape must be {}, got {}'.format(shape, actual_shape)
+        )
+    if array.dtype != np.uint32:
+        raise TypeError(
+            'output dtype must be uint32, got {}'.format(array.dtype)
+        )
+    if not array.flags.c_contiguous:
+        raise ValueError('output must be C-contiguous')
+    if not array.flags.writeable:
+        raise ValueError('output must be writable')
+    return array
+
+
+cdef void _copy_screen_rgb_pixels(
+    NES_Pixel* source,
+    uint8_t* out,
+) noexcept nogil:
+    """Copy a native 32-bit screen buffer into contiguous RGB bytes."""
+    cdef size_t index
+    cdef size_t out_index
+    cdef size_t pixel_count = SCREEN_WIDTH_C * SCREEN_HEIGHT_C
+    cdef NES_Pixel pixel
+    for index in range(pixel_count):
+        pixel = source[index]
+        out_index = index * 3
+        out[out_index] = <uint8_t>((pixel >> 16) & 0xff)
+        out[out_index + 1] = <uint8_t>((pixel >> 8) & 0xff)
+        out[out_index + 2] = <uint8_t>(pixel & 0xff)
+
+
+cdef void _copy_screen_grayscale_pixels(
+    NES_Pixel* source,
+    uint8_t* out,
+) noexcept nogil:
+    """Copy a native 32-bit screen buffer into contiguous luma bytes."""
+    cdef size_t index
+    cdef size_t pixel_count = SCREEN_WIDTH_C * SCREEN_HEIGHT_C
+    cdef NES_Pixel pixel
+    cdef uint32_t r
+    cdef uint32_t g
+    cdef uint32_t b
+    for index in range(pixel_count):
+        pixel = source[index]
+        r = (pixel >> 16) & 0xff
+        g = (pixel >> 8) & 0xff
+        b = pixel & 0xff
+        out[index] = <uint8_t>((77 * r + 150 * g + 29 * b) >> 8)
+
+
+cdef void _read_ram_values_into(
+    NES_Byte* ram,
+    uint16_t* addresses,
+    uint8_t* sizes,
+    uint8_t* encodings,
+    size_t spec_count,
+    uint32_t* out,
+) noexcept nogil:
+    """Read configured RAM values into a uint32 output row."""
+    cdef size_t spec_index
+    cdef size_t byte_index
+    cdef uint16_t address
+    cdef uint8_t size
+    cdef uint8_t encoding
+    cdef NES_Byte value
+    cdef uint32_t decoded
+    for spec_index in range(spec_count):
+        address = addresses[spec_index]
+        size = sizes[spec_index]
+        encoding = encodings[spec_index]
+        if encoding == RAM_READ_ENCODING_BYTE_CODE:
+            out[spec_index] = <uint32_t> ram[address]
+        elif encoding == RAM_READ_ENCODING_LITTLE_CODE:
+            decoded = 0
+            for byte_index in range(size):
+                decoded |= (
+                    <uint32_t> ram[address + byte_index]
+                ) << (8 * byte_index)
+            out[spec_index] = decoded
+        elif encoding == RAM_READ_ENCODING_BIG_CODE:
+            decoded = 0
+            for byte_index in range(size):
+                decoded = (decoded << 8) | ram[address + byte_index]
+            out[spec_index] = decoded
+        elif encoding == RAM_READ_ENCODING_BCD_CODE:
+            decoded = 0
+            for byte_index in range(size):
+                value = ram[address + byte_index]
+                decoded *= 100
+                decoded += ((value >> 4) & 0x0f) * 10 + (value & 0x0f)
+            out[spec_index] = decoded
+        else:
+            decoded = 0
+            for byte_index in range(size):
+                decoded *= 10
+                decoded += ram[address + byte_index]
+            out[spec_index] = decoded
+
+
+cdef cnp.ndarray _validated_ram_addresses(object addresses):
+    """Return a C-contiguous uint16 address array."""
+    cdef cnp.ndarray array = np.asarray(addresses)
+    if array.ndim != 1:
+        raise ValueError('addresses must be a one-dimensional array')
+    if array.dtype != np.uint16:
+        raise TypeError('addresses dtype must be uint16')
+    if not array.flags.c_contiguous:
+        raise ValueError('addresses must be C-contiguous')
+    return array
+
+
+cdef cnp.ndarray _validated_ram_metadata(object values, str name):
+    """Return a C-contiguous uint8 RAM metadata array."""
+    cdef cnp.ndarray array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError('{} must be a one-dimensional array'.format(name))
+    if array.dtype != np.uint8:
+        raise TypeError('{} dtype must be uint8'.format(name))
+    if not array.flags.c_contiguous:
+        raise ValueError('{} must be C-contiguous'.format(name))
+    return array
+
+
+cdef void _validate_ram_spec_arrays(
+    cnp.ndarray addresses,
+    cnp.ndarray sizes,
+    cnp.ndarray encodings,
+) except *:
+    """Validate parsed RAM-read spec arrays agree on length."""
+    if sizes.shape[0] != addresses.shape[0]:
+        raise ValueError('sizes length must match addresses length')
+    if encodings.shape[0] != addresses.shape[0]:
+        raise ValueError('encodings length must match addresses length')
+
+
+cdef class NativeStateSnapshot:
+    """Opaque Python owner for ``NES::Emulator::Snapshot``."""
+
+    cdef EmulatorSnapshot* _snapshot
+
+    def __cinit__(self):
+        self._snapshot = NULL
+
+    def __dealloc__(self):
+        if self._snapshot != NULL:
+            del self._snapshot
+            self._snapshot = NULL
+
+    cdef void _set(self, const EmulatorSnapshot& snapshot) except *:
+        if self._snapshot != NULL:
+            del self._snapshot
+        self._snapshot = new EmulatorSnapshot(snapshot)
+
+    cdef void _set_ptr(self, EmulatorSnapshot* snapshot) except *:
+        if snapshot == NULL:
+            raise MemoryError()
+        if self._snapshot != NULL:
+            del self._snapshot
+        self._snapshot = snapshot
+
+    cdef const EmulatorSnapshot& _get(self) except *:
+        if self._snapshot == NULL:
+            raise ValueError('snapshot has not been initialized.')
+        return self._snapshot[0]
+
+
 cdef class NativeEmulator:
     """Python-owned wrapper around ``NES::Emulator``."""
 
@@ -184,17 +383,8 @@ cdef class NativeEmulator:
         )
         cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
         cdef NES_Pixel* source = self._emu.get_screen_buffer()
-        cdef size_t index
-        cdef size_t out_index
-        cdef size_t pixel_count = SCREEN_WIDTH * SCREEN_HEIGHT
-        cdef NES_Pixel pixel
         with nogil:
-            for index in range(pixel_count):
-                pixel = source[index]
-                out_index = index * 3
-                out[out_index] = <uint8_t>((pixel >> 16) & 0xff)
-                out[out_index + 1] = <uint8_t>((pixel >> 8) & 0xff)
-                out[out_index + 2] = <uint8_t>(pixel & 0xff)
+            _copy_screen_rgb_pixels(source, out)
         return array
 
     def copy_screen_grayscale(self, object output=None):
@@ -206,19 +396,8 @@ cdef class NativeEmulator:
         )
         cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
         cdef NES_Pixel* source = self._emu.get_screen_buffer()
-        cdef size_t index
-        cdef size_t pixel_count = SCREEN_WIDTH * SCREEN_HEIGHT
-        cdef NES_Pixel pixel
-        cdef uint32_t r
-        cdef uint32_t g
-        cdef uint32_t b
         with nogil:
-            for index in range(pixel_count):
-                pixel = source[index]
-                r = (pixel >> 16) & 0xff
-                g = (pixel >> 8) & 0xff
-                b = pixel & 0xff
-                out[index] = <uint8_t>((77 * r + 150 * g + 29 * b) >> 8)
+            _copy_screen_grayscale_pixels(source, out)
         return array
 
     def ram_buffer(self):
@@ -275,6 +454,62 @@ cdef class NativeEmulator:
         self._require_open()
         self._emu.restore()
 
+    def dump_state(self):
+        """Return an opaque owned snapshot of the emulator state."""
+        self._require_open()
+        cdef NativeStateSnapshot snapshot = NativeStateSnapshot()
+        snapshot._set_ptr(self._emu.create_snapshot())
+        return snapshot
+
+    def load_state(self, object snapshot):
+        """Restore the emulator from an opaque state snapshot."""
+        self._require_open()
+        if not isinstance(snapshot, NativeStateSnapshot):
+            raise TypeError('snapshot must be a NativeStateSnapshot')
+        (<NativeStateSnapshot> snapshot)._get()
+        self._emu.load_snapshot((<NativeStateSnapshot> snapshot)._snapshot)
+
+    def read_ram_values(
+        self,
+        object addresses,
+        object sizes,
+        object encodings,
+        object output=None,
+    ):
+        """Read configured RAM values into a reusable uint32 array."""
+        self._require_open()
+        cdef cnp.ndarray address_array = _validated_ram_addresses(addresses)
+        cdef cnp.ndarray size_array = _validated_ram_metadata(sizes, 'sizes')
+        cdef cnp.ndarray encoding_array = _validated_ram_metadata(
+            encodings,
+            'encodings',
+        )
+        _validate_ram_spec_arrays(address_array, size_array, encoding_array)
+        cdef cnp.ndarray out_array = _validated_uint32_output(
+            output,
+            (address_array.shape[0],),
+        )
+        cdef uint16_t* address_data = <uint16_t*> cnp.PyArray_DATA(
+            address_array
+        )
+        cdef uint8_t* size_data = <uint8_t*> cnp.PyArray_DATA(size_array)
+        cdef uint8_t* encoding_data = <uint8_t*> cnp.PyArray_DATA(
+            encoding_array
+        )
+        cdef uint32_t* out = <uint32_t*> cnp.PyArray_DATA(out_array)
+        cdef NES_Byte* ram = self._emu.get_memory_buffer()
+        cdef size_t spec_count = <size_t> address_array.shape[0]
+        with nogil:
+            _read_ram_values_into(
+                ram,
+                address_data,
+                size_data,
+                encoding_data,
+                spec_count,
+                out,
+            )
+        return out_array
+
     def mapper_number(self):
         """Return the active mapper number."""
         self._require_open()
@@ -299,6 +534,291 @@ cdef class NativeEmulator:
         """Return the active mapper's name table mirroring mode."""
         self._require_open()
         return int(self._emu.get_name_table_mirroring())
+
+
+cdef class NativeVectorEmulator:
+    """Python-owned wrapper around a same-ROM group of native emulators."""
+
+    cdef Emulator** _emus
+    cdef size_t _env_count
+    cdef bint _closed
+
+    def __cinit__(self, object rom_path, object env_count):
+        cdef object requested_count = int(env_count)
+        cdef size_t index
+        cdef string path
+        self._emus = NULL
+        self._env_count = 0
+        self._closed = True
+        if requested_count <= 0:
+            raise ValueError('env_count must be positive')
+        self._env_count = <size_t> requested_count
+        self._emus = <Emulator**> malloc(self._env_count * sizeof(Emulator*))
+        if self._emus == NULL:
+            self._env_count = 0
+            raise MemoryError()
+        for index in range(self._env_count):
+            self._emus[index] = NULL
+        path = _rom_path_string(rom_path)
+        try:
+            for index in range(self._env_count):
+                self._emus[index] = new Emulator(path)
+        except Exception:
+            self._free_emulators()
+            raise
+        self._closed = False
+
+    def __dealloc__(self):
+        self._free_emulators()
+
+    cdef void _free_emulators(self):
+        cdef size_t index
+        if self._emus != NULL:
+            for index in range(self._env_count):
+                if self._emus[index] != NULL:
+                    del self._emus[index]
+                    self._emus[index] = NULL
+            free(self._emus)
+            self._emus = NULL
+        self._env_count = 0
+        self._closed = True
+
+    cdef void _require_open(self) except *:
+        if self._closed or self._emus == NULL:
+            raise ValueError('vector emulator has already been closed.')
+
+    cdef Py_ssize_t _require_index(self, object index) except -1:
+        cdef Py_ssize_t value = int(index)
+        if value < 0 or value >= <Py_ssize_t> self._env_count:
+            raise IndexError('env index out of range')
+        return value
+
+    cdef cnp.ndarray _validated_actions(self, object actions):
+        cdef cnp.ndarray array = np.asarray(actions)
+        cdef object actual_shape
+        if array.ndim != 1:
+            raise ValueError('actions must be a one-dimensional uint8 array')
+        actual_shape = np.shape(array)
+        if array.shape[0] != <Py_ssize_t> self._env_count:
+            raise ValueError(
+                'actions shape must be ({},), got {}'.format(
+                    int(self._env_count),
+                    actual_shape,
+                )
+            )
+        if array.dtype != np.uint8:
+            raise TypeError('actions dtype must be uint8')
+        if not array.flags.c_contiguous:
+            raise ValueError('actions must be C-contiguous')
+        return array
+
+    def close(self):
+        """Close native operations while outstanding views stay valid."""
+        self._require_open()
+        self._closed = True
+
+    @property
+    def env_count(self):
+        """Return the number of native emulator instances."""
+        return int(self._env_count)
+
+    def screen_buffer(self, object index):
+        """Return a no-copy RGB view for one vector slot."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        cdef cnp.npy_intp dims[3]
+        cdef cnp.npy_intp strides[3]
+        cdef uint8_t* data = <uint8_t*> (
+            self._emus[env_index].get_screen_buffer()
+        )
+        dims[0] = SCREEN_HEIGHT
+        dims[1] = SCREEN_WIDTH
+        dims[2] = 3
+        strides[0] = SCREEN_WIDTH * 4
+        strides[1] = 4
+        if sys.byteorder == 'little':
+            data += 2
+            strides[2] = -1
+        else:
+            data += 1
+            strides[2] = 1
+        return _uint8_array(3, dims, strides, <void*> data, self)
+
+    def ram_buffer(self, object index):
+        """Return a no-copy RAM view for one vector slot."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        cdef cnp.npy_intp dims[1]
+        cdef cnp.npy_intp strides[1]
+        dims[0] = RAM_SIZE
+        strides[0] = 1
+        return _uint8_array(
+            1,
+            dims,
+            strides,
+            <void*> self._emus[env_index].get_memory_buffer(),
+            self,
+        )
+
+    def reset(self):
+        """Reset all emulator instances."""
+        self._require_open()
+        cdef size_t index
+        with nogil:
+            for index in range(self._env_count):
+                self._emus[index].reset()
+
+    def reset_one(self, object index):
+        """Reset one emulator instance."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        with nogil:
+            self._emus[env_index].reset()
+
+    def step(self, object actions):
+        """Apply per-env actions and advance each emulator by one frame."""
+        self._require_open()
+        cdef cnp.ndarray action_array = self._validated_actions(actions)
+        cdef uint8_t* action_data = <uint8_t*> cnp.PyArray_DATA(action_array)
+        cdef size_t index
+        for index in range(self._env_count):
+            self._emus[index].get_controller(0)[0] = <NES_Byte> action_data[index]
+        with nogil:
+            for index in range(self._env_count):
+                self._emus[index].step()
+
+    def step_one(self, object index, object action):
+        """Apply one action and advance one emulator by one frame."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        self._emus[env_index].get_controller(0)[0] = <NES_Byte> int(action)
+        with nogil:
+            self._emus[env_index].step()
+
+    def copy_screen_rgb(self, object index, object output=None):
+        """Copy one vector slot screen to a contiguous RGB array."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        cdef cnp.ndarray array = _validated_uint8_output(
+            output,
+            (SCREEN_HEIGHT, SCREEN_WIDTH, 3),
+        )
+        cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
+        cdef NES_Pixel* source = self._emus[env_index].get_screen_buffer()
+        with nogil:
+            _copy_screen_rgb_pixels(source, out)
+        return array
+
+    def copy_screen_grayscale(self, object index, object output=None):
+        """Copy one vector slot screen to a contiguous grayscale array."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        cdef cnp.ndarray array = _validated_uint8_output(
+            output,
+            (SCREEN_HEIGHT, SCREEN_WIDTH),
+        )
+        cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
+        cdef NES_Pixel* source = self._emus[env_index].get_screen_buffer()
+        with nogil:
+            _copy_screen_grayscale_pixels(source, out)
+        return array
+
+    def copy_screen_rgb_batch(self, object output=None):
+        """Copy all screens to a contiguous batch RGB array."""
+        self._require_open()
+        cdef cnp.ndarray array = _validated_uint8_output(
+            output,
+            (int(self._env_count), SCREEN_HEIGHT, SCREEN_WIDTH, 3),
+        )
+        cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
+        cdef size_t index
+        cdef size_t stride = SCREEN_HEIGHT_C * SCREEN_WIDTH_C * 3
+        with nogil:
+            for index in range(self._env_count):
+                _copy_screen_rgb_pixels(
+                    self._emus[index].get_screen_buffer(),
+                    out + index * stride,
+                )
+        return array
+
+    def copy_screen_grayscale_batch(self, object output=None):
+        """Copy all screens to a contiguous batch grayscale array."""
+        self._require_open()
+        cdef cnp.ndarray array = _validated_uint8_output(
+            output,
+            (int(self._env_count), SCREEN_HEIGHT, SCREEN_WIDTH),
+        )
+        cdef uint8_t* out = <uint8_t*> cnp.PyArray_DATA(array)
+        cdef size_t index
+        cdef size_t stride = SCREEN_HEIGHT_C * SCREEN_WIDTH_C
+        with nogil:
+            for index in range(self._env_count):
+                _copy_screen_grayscale_pixels(
+                    self._emus[index].get_screen_buffer(),
+                    out + index * stride,
+                )
+        return array
+
+    def dump_state(self, object index):
+        """Return an opaque snapshot for one vector slot."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        cdef NativeStateSnapshot snapshot = NativeStateSnapshot()
+        snapshot._set_ptr(self._emus[env_index].create_snapshot())
+        return snapshot
+
+    def load_state(self, object index, object snapshot):
+        """Restore one vector slot from an opaque snapshot."""
+        self._require_open()
+        cdef Py_ssize_t env_index = self._require_index(index)
+        if not isinstance(snapshot, NativeStateSnapshot):
+            raise TypeError('snapshot must be a NativeStateSnapshot')
+        (<NativeStateSnapshot> snapshot)._get()
+        self._emus[env_index].load_snapshot(
+            (<NativeStateSnapshot> snapshot)._snapshot
+        )
+
+    def read_ram_values(
+        self,
+        object addresses,
+        object sizes,
+        object encodings,
+        object output=None,
+    ):
+        """Read configured RAM values for every vector slot."""
+        self._require_open()
+        cdef cnp.ndarray address_array = _validated_ram_addresses(addresses)
+        cdef cnp.ndarray size_array = _validated_ram_metadata(sizes, 'sizes')
+        cdef cnp.ndarray encoding_array = _validated_ram_metadata(
+            encodings,
+            'encodings',
+        )
+        _validate_ram_spec_arrays(address_array, size_array, encoding_array)
+        cdef cnp.ndarray out_array = _validated_uint32_output(
+            output,
+            (int(self._env_count), address_array.shape[0]),
+        )
+        cdef uint16_t* address_data = <uint16_t*> cnp.PyArray_DATA(
+            address_array
+        )
+        cdef uint8_t* size_data = <uint8_t*> cnp.PyArray_DATA(size_array)
+        cdef uint8_t* encoding_data = <uint8_t*> cnp.PyArray_DATA(
+            encoding_array
+        )
+        cdef uint32_t* out = <uint32_t*> cnp.PyArray_DATA(out_array)
+        cdef size_t spec_count = <size_t> address_array.shape[0]
+        cdef size_t index
+        with nogil:
+            for index in range(self._env_count):
+                _read_ram_values_into(
+                    self._emus[index].get_memory_buffer(),
+                    address_data,
+                    size_data,
+                    encoding_data,
+                    spec_count,
+                    out + index * spec_count,
+                )
+        return out_array
 
 
 def cartridge_error(object rom_path):

--- a/nes_py/nes_env.py
+++ b/nes_py/nes_env.py
@@ -35,6 +35,13 @@ SCREEN_WIDTH = _native.SCREEN_WIDTH
 SCREEN_SHAPE_24_BIT = SCREEN_HEIGHT, SCREEN_WIDTH, 3
 # shape of the screen as 32-bit RGB (C++ memory arrangement)
 SCREEN_SHAPE_32_BIT = SCREEN_HEIGHT, SCREEN_WIDTH, 4
+# shape of a grayscale screen observation
+SCREEN_SHAPE_GRAYSCALE = SCREEN_HEIGHT, SCREEN_WIDTH
+
+
+OBSERVATION_MODE_RGB_ARRAY = 'rgb_array'
+OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS = 'rgb_array_contiguous'
+OBSERVATION_MODE_GRAYSCALE = 'grayscale'
 
 
 class NESEnv(gym.Env):
@@ -117,6 +124,32 @@ class NESEnv(gym.Env):
     def _screen_buffer(self):
         """Setup the screen buffer from the C++ code."""
         return self._env.screen_buffer()
+
+    def observation(self, mode=OBSERVATION_MODE_RGB_ARRAY, output=None):
+        """
+        Return the current screen using an explicit observation mode.
+
+        The default mode returns the same zero-copy view as ``self.screen``.
+        Copy modes return C-contiguous ``uint8`` arrays and may write into the
+        optional ``output`` array to support allocation-free ML loops.
+        """
+        if mode == OBSERVATION_MODE_RGB_ARRAY:
+            return self.screen
+        if self._env is None:
+            raise ValueError('env has already been closed.')
+        if mode == OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS:
+            return self._env.copy_screen_rgb(output)
+        if mode == OBSERVATION_MODE_GRAYSCALE:
+            return self._env.copy_screen_grayscale(output)
+        modes = (
+            OBSERVATION_MODE_RGB_ARRAY,
+            OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+            OBSERVATION_MODE_GRAYSCALE,
+        )
+        msg = 'valid observation modes are: {}'.format(
+            ', '.join(repr(mode) for mode in modes)
+        )
+        raise NotImplementedError(msg)
 
     def _ram_buffer(self):
         """Setup the RAM buffer from the C++ code."""

--- a/nes_py/nes_env.py
+++ b/nes_py/nes_env.py
@@ -10,6 +10,7 @@ import numpy as np
 from ._rom import ROM
 from ._image_viewer import ImageViewer
 from . import _native
+from .ram import normalize_ram_read_specs
 
 
 def _native_cartridge_error(rom_path):
@@ -209,6 +210,31 @@ class NESEnv(gym.Env):
     def _restore(self):
         """Restore the backup state into the NES emulator."""
         self._env.restore()
+
+    def dump_state(self):
+        """Return an opaque snapshot of the native emulator state."""
+        if self._env is None:
+            raise ValueError('env has already been closed.')
+        return self._env.dump_state()
+
+    def load_state(self, snapshot):
+        """Restore the native emulator from an opaque state snapshot."""
+        if self._env is None:
+            raise ValueError('env has already been closed.')
+        self._env.load_state(snapshot)
+        self.done = False
+
+    def ram_values(self, specs, output=None):
+        """Read configured RAM values into a reusable uint32 array."""
+        if self._env is None:
+            raise ValueError('env has already been closed.')
+        addresses, sizes, encodings = normalize_ram_read_specs(specs)
+        return self._env.read_ram_values(
+            addresses,
+            sizes,
+            encodings,
+            output,
+        )
 
     def _will_reset(self):
         """Handle any RAM hacking after a reset occurs."""

--- a/nes_py/ram.py
+++ b/nes_py/ram.py
@@ -1,0 +1,117 @@
+"""Generic RAM read descriptors for NES training-loop helpers."""
+import numpy as np
+
+from . import _native
+
+
+RAM_READ_ENCODINGS = {
+    'byte': _native.RAM_READ_ENCODING_BYTE,
+    'little': _native.RAM_READ_ENCODING_LITTLE,
+    'big': _native.RAM_READ_ENCODING_BIG,
+    'bcd': _native.RAM_READ_ENCODING_BCD,
+    'digits': _native.RAM_READ_ENCODING_DIGITS,
+}
+
+
+def _coerce_int(name, value):
+    """Return ``value`` as an integer or raise a helpful error."""
+    try:
+        return int(value)
+    except (TypeError, ValueError) as error:
+        raise TypeError('{} must be an integer'.format(name)) from error
+
+
+def _normalize_mapping(spec):
+    """Return address, size, and encoding from a mapping descriptor."""
+    if 'address' not in spec:
+        raise ValueError('RAM read mapping specs require an address')
+    return (
+        spec['address'],
+        spec.get('size', 1),
+        spec.get('encoding', 'byte'),
+    )
+
+
+def _normalize_sequence(spec):
+    """Return address, size, and encoding from a sequence descriptor."""
+    if len(spec) == 2:
+        return spec[0], spec[1], 'little'
+    if len(spec) == 3:
+        return spec[0], spec[1], spec[2]
+    raise ValueError(
+        'RAM read tuple specs must be (address, size) or '
+        '(address, size, encoding)'
+    )
+
+
+def _normalize_one(spec):
+    """Return one validated RAM read descriptor tuple."""
+    if isinstance(spec, dict):
+        address, size, encoding = _normalize_mapping(spec)
+    elif isinstance(spec, (int, np.integer)):
+        address, size, encoding = spec, 1, 'byte'
+    else:
+        try:
+            address, size, encoding = _normalize_sequence(tuple(spec))
+        except TypeError as error:
+            raise TypeError(
+                'RAM read specs must be integers, mappings, or tuples'
+            ) from error
+
+    address = _coerce_int('address', address)
+    size = _coerce_int('size', size)
+    encoding = str(encoding).lower()
+    if encoding not in RAM_READ_ENCODINGS:
+        raise ValueError('unknown RAM read encoding: {}'.format(encoding))
+    if address < 0 or address >= _native.RAM_SIZE:
+        raise ValueError('address must be in [0, 0x800)')
+    if size <= 0:
+        raise ValueError('size must be positive')
+    if address + size > _native.RAM_SIZE:
+        raise ValueError('RAM read extends past 0x800 bytes')
+    if encoding == 'byte' and size != 1:
+        raise ValueError('byte RAM reads must use size 1')
+    if encoding in {'little', 'big', 'bcd'} and size > 4:
+        raise ValueError('{} RAM reads support sizes up to 4'.format(
+            encoding
+        ))
+    if encoding == 'digits' and size > 9:
+        raise ValueError('digits RAM reads support sizes up to 9')
+    return address, size, RAM_READ_ENCODINGS[encoding]
+
+
+def normalize_ram_read_specs(specs):
+    """
+    Normalize public RAM read descriptors for native batch reads.
+
+    Supported descriptors are:
+
+    - ``address``: read one byte.
+    - ``(address, size)``: read a little-endian unsigned integer.
+    - ``(address, size, encoding)``: read using ``byte``, ``little``, ``big``,
+      ``bcd``, or ``digits``.
+    - ``{"address": ..., "size": ..., "encoding": ...}``: mapping form of
+      the tuple descriptor.
+    """
+    if specs is None:
+        raise TypeError('RAM read specs are required')
+    try:
+        normalized = [_normalize_one(spec) for spec in specs]
+    except TypeError as error:
+        raise TypeError('RAM read specs must be iterable') from error
+
+    count = len(normalized)
+    addresses = np.empty(count, dtype=np.uint16)
+    sizes = np.empty(count, dtype=np.uint8)
+    encodings = np.empty(count, dtype=np.uint8)
+    for index, (address, size, encoding) in enumerate(normalized):
+        addresses[index] = address
+        sizes[index] = size
+        encodings[index] = encoding
+    return addresses, sizes, encodings
+
+
+__all__ = [
+    'RAM_READ_ENCODINGS',
+    'normalize_ram_read_specs',
+]

--- a/nes_py/speedtest.py
+++ b/nes_py/speedtest.py
@@ -7,17 +7,22 @@ import sysconfig
 import time
 from dataclasses import asdict
 from dataclasses import dataclass
+from statistics import median
 from typing import Callable
 
+import gymnasium as gym
 import numpy as np
 from tqdm import tqdm
 
 from ._rom import ROM
 from .nes_env import NESEnv
 from .nes_env import OBSERVATION_MODE_GRAYSCALE
+from .nes_env import OBSERVATION_MODE_RGB_ARRAY
 from .nes_env import OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS
 from .nes_env import SCREEN_SHAPE_24_BIT
 from .nes_env import SCREEN_SHAPE_GRAYSCALE
+from .ram import normalize_ram_read_specs
+from .vector_env import VectorNESEmulator
 
 
 ActionPolicy = Callable[[NESEnv, int, np.random.RandomState], int] | str
@@ -29,6 +34,43 @@ OBSERVATION_PROFILE_OPERATIONS = (
     'step_native_rgb_contiguous',
     'step_native_grayscale',
 )
+RAM_PROFILE_OPERATIONS = (
+    'python_indexing',
+    'numpy_take',
+    'native_batch',
+    'step_python_indexing',
+    'step_native_batch',
+)
+VECTOR_PROFILE_BACKENDS = (
+    'scalar_loop',
+    'gym_sync_vector_env',
+    'gym_async_vector_env',
+    'native_vector',
+)
+VECTOR_PROFILE_OBSERVATIONS = (
+    'step_only',
+    'native_rgb_contiguous',
+    'native_grayscale',
+    'ram_info',
+)
+DEFAULT_RAM_READ_SPECS = (
+    0x0000,
+    0x0001,
+    (0x0002, 2, 'little'),
+    (0x0004, 2, 'big'),
+    (0x0006, 2, 'bcd'),
+    (0x0008, 3, 'digits'),
+)
+
+
+class _NESEnvFactory:
+    """Picklable factory used by Gymnasium vector baselines."""
+
+    def __init__(self, rom):
+        self.rom = rom
+
+    def __call__(self):
+        return NESEnv(self.rom)
 
 
 @dataclass(frozen=True)
@@ -112,6 +154,81 @@ class ObservationBenchmarkResult:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class RepeatedBenchmarkSummary:
+    """Summary statistics for repeated benchmark measurements."""
+
+    operation: str
+    runs: int
+    median_steps_per_second: float
+    min_steps_per_second: float
+    max_steps_per_second: float
+    iqr_steps_per_second: float
+    baseline_steps_per_second: float | None = None
+    percent_change: float | None = None
+
+    def to_dict(self):
+        """Return this summary as a JSON-serializable dictionary."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RAMReadBenchmarkResult:
+    """Structured result from a RAM/info read benchmark."""
+
+    environment: str
+    compiler: str
+    platform: str
+    rom: str
+    operation: str
+    action_policy: str
+    total_steps: int
+    warmup_steps: int
+    ram_read_count: int
+    elapsed_seconds: float
+    steps_per_second: float
+    checksum: int
+
+    def to_dict(self):
+        """Return this result as a JSON-serializable dictionary."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VectorBenchmarkResult:
+    """Structured result from a vector throughput benchmark."""
+
+    environment: str
+    compiler: str
+    platform: str
+    rom: str
+    backend: str
+    env_count: int
+    observation_mode: str
+    action_policy: str
+    total_steps: int
+    warmup_steps: int
+    measured_frames: int
+    elapsed_seconds: float
+    frames_per_second: float
+    instrumentation_enabled: bool
+    cpu_affinity: str
+    setup_seconds: float = 0.0
+    action_transfer_seconds: float = 0.0
+    native_step_seconds: float = 0.0
+    synchronization_seconds: float = 0.0
+    observation_seconds: float = 0.0
+    ram_info_seconds: float = 0.0
+    python_overhead_seconds: float = 0.0
+    teardown_seconds: float = 0.0
+    worker_stats: tuple = ()
+    checksum: int = 0
+
+    def to_dict(self):
+        """Return this result as a JSON-serializable dictionary."""
+        return asdict(self)
+
+
 def _validate_non_negative(name, value):
     """Validate a non-negative integer CLI/API value."""
     if value < 0:
@@ -179,6 +296,44 @@ def _environment_name():
 def _compiler_name():
     """Return the compiler configured for this Python runtime."""
     return sysconfig.get_config_var('CC') or 'unknown'
+
+
+def _percent_change(value, baseline):
+    """Return percent change from baseline, or None for a zero baseline."""
+    if baseline in (None, 0):
+        return None
+    return 100.0 * (value - baseline) / baseline
+
+
+def _iqr(values):
+    """Return a small-sample interquartile range for benchmark values."""
+    ordered = sorted(values)
+    if len(ordered) < 4:
+        return ordered[-1] - ordered[0] if ordered else 0.0
+    q1_index = (len(ordered) - 1) // 4
+    q3_index = (3 * (len(ordered) - 1)) // 4
+    return ordered[q3_index] - ordered[q1_index]
+
+
+def summarize_repeated_results(results, operation, baseline=None):
+    """Summarize repeated results that expose steps or frames per second."""
+    values = []
+    for result in results:
+        if hasattr(result, 'frames_per_second'):
+            values.append(result.frames_per_second)
+        else:
+            values.append(result.steps_per_second)
+    summary_median = median(values)
+    return RepeatedBenchmarkSummary(
+        operation=operation,
+        runs=len(values),
+        median_steps_per_second=summary_median,
+        min_steps_per_second=min(values),
+        max_steps_per_second=max(values),
+        iqr_steps_per_second=_iqr(values),
+        baseline_steps_per_second=baseline,
+        percent_change=_percent_change(summary_median, baseline),
+    )
 
 
 def _measure_mapper_operation(env, operation, steps, warmup_steps):
@@ -393,6 +548,165 @@ def run_observation_profile(
     return results
 
 
+def _default_ram_read_specs():
+    """Return a mutable copy of the synthetic wrapper-like RAM read set."""
+    return tuple(DEFAULT_RAM_READ_SPECS)
+
+
+def _python_ram_values(ram, addresses, sizes, encodings):
+    """Decode RAM values with Python indexing for baseline profiling."""
+    values = []
+    for address, size, encoding in zip(addresses, sizes, encodings):
+        address = int(address)
+        size = int(size)
+        encoding = int(encoding)
+        if encoding == 0:
+            values.append(int(ram[address]))
+        elif encoding == 1:
+            value = 0
+            for offset in range(size):
+                value |= int(ram[address + offset]) << (8 * offset)
+            values.append(value)
+        elif encoding == 2:
+            value = 0
+            for offset in range(size):
+                value = (value << 8) | int(ram[address + offset])
+            values.append(value)
+        elif encoding == 3:
+            value = 0
+            for offset in range(size):
+                byte = int(ram[address + offset])
+                value = value * 100 + ((byte >> 4) & 0x0f) * 10 + (byte & 0x0f)
+            values.append(value)
+        else:
+            value = 0
+            for offset in range(size):
+                value = value * 10 + int(ram[address + offset])
+            values.append(value)
+    return values
+
+
+def _measure_ram_operation(
+    env,
+    operation,
+    action,
+    rng,
+    steps,
+    warmup_steps,
+    seed,
+    specs,
+):
+    """Measure one RAM/info collection operation."""
+    addresses, sizes, encodings = normalize_ram_read_specs(specs)
+    output = np.empty((len(addresses),), dtype=np.uint32)
+    take_addresses = addresses.astype(np.intp, copy=False)
+    total = steps + warmup_steps
+    checksum = 0
+    done = True
+    resets = 0
+    started_at = None
+
+    for step_number in range(1, total + 1):
+        if done:
+            _reset(env, seed if resets == 0 else None)
+            resets += 1
+            done = False
+        if step_number == warmup_steps + 1:
+            started_at = time.perf_counter()
+
+        if operation.startswith('step_'):
+            _, _, done, _ = _step(env, action(env, step_number, rng))
+
+        if operation in {'python_indexing', 'step_python_indexing'}:
+            values = _python_ram_values(env.ram, addresses, sizes, encodings)
+            checksum ^= int(values[0]) if values else 0
+        elif operation == 'numpy_take':
+            values = np.take(env.ram, take_addresses)
+            checksum ^= int(values[0]) if len(values) else 0
+        elif operation in {'native_batch', 'step_native_batch'}:
+            values = env.ram_values(specs, output=output)
+            checksum ^= int(values[0]) if len(values) else 0
+        else:
+            raise ValueError('unknown RAM benchmark operation: {}'.format(
+                operation
+            ))
+
+    elapsed = time.perf_counter() - started_at
+    steps_per_second = steps / elapsed if elapsed > 0 else 0.0
+    return elapsed, steps_per_second, checksum, len(addresses)
+
+
+def run_ram_profile(
+    rom,
+    steps=5000,
+    warmup_steps=0,
+    seed=None,
+    action_policy='random',
+    specs=None,
+    operations=None,
+):
+    """
+    Run RAM/info collection benchmarks for wrapper-style loops.
+
+    The profile compares pure Python indexing, NumPy gathers for plain byte
+    reads, and the native batch helper both in isolation and after stepping.
+    """
+    if steps <= 0:
+        raise ValueError('steps must be positive')
+    _validate_non_negative('warmup_steps', warmup_steps)
+    if specs is None:
+        specs = _default_ram_read_specs()
+    if operations is None:
+        operations = RAM_PROFILE_OPERATIONS
+
+    action, action_name = _resolve_action(action_policy)
+    results = []
+    for operation in operations:
+        rng = np.random.RandomState(seed)
+        env = NESEnv(rom)
+        try:
+            elapsed, steps_per_second, checksum, read_count = (
+                _measure_ram_operation(
+                    env,
+                    operation,
+                    action,
+                    rng,
+                    steps,
+                    warmup_steps,
+                    seed,
+                    specs,
+                )
+            )
+        finally:
+            env.close()
+        results.append(RAMReadBenchmarkResult(
+            environment=_environment_name(),
+            compiler=_compiler_name(),
+            platform=platform_module.platform(),
+            rom=rom,
+            operation=operation,
+            action_policy=action_name,
+            total_steps=steps + warmup_steps,
+            warmup_steps=warmup_steps,
+            ram_read_count=read_count,
+            elapsed_seconds=elapsed,
+            steps_per_second=steps_per_second,
+            checksum=checksum,
+        ))
+
+    return results
+
+
+def run_repeated_benchmark(config=None, runs=5, **kwargs):
+    """Run scalar throughput benchmark repeatedly and summarize spread."""
+    if runs <= 0:
+        raise ValueError('runs must be positive')
+    results = []
+    for _ in range(runs):
+        results.append(run_benchmark(config, **kwargs))
+    return results, summarize_repeated_results(results, 'scalar')
+
+
 def run_benchmark(config=None, **kwargs):
     """
     Run an NES throughput benchmark and return a structured result.
@@ -501,6 +815,508 @@ def run_benchmark(config=None, **kwargs):
     )
 
 
+def _vector_action_array(policy, env_count, step, rng):
+    """Return one uint8 action per vector slot."""
+    if policy == 'noop':
+        return np.zeros((env_count,), dtype=np.uint8)
+    if policy == 'random':
+        return rng.randint(256, size=env_count).astype(np.uint8)
+    raise ValueError('unknown action policy: {}'.format(policy))
+
+
+def _consume_vector_observation(mode, observations, checksum):
+    """Consume a vector observation array or tuple for benchmark accounting."""
+    if mode == 'step_only':
+        return checksum
+    if isinstance(observations, tuple):
+        if not observations:
+            return checksum
+        return checksum ^ int(np.asarray(observations[0]).flat[0])
+    return checksum ^ _consume_observation_output(observations)
+
+
+def _measure_scalar_vector_loop(
+    rom,
+    env_count,
+    steps,
+    warmup_steps,
+    seed,
+    action_policy,
+    observation_mode,
+    ram_specs,
+    instrumentation_enabled,
+    cpu_affinity,
+):
+    """Measure a Python loop over scalar NESEnv instances."""
+    del instrumentation_enabled
+    setup_started_at = time.perf_counter()
+    envs = [NESEnv(rom) for _ in range(env_count)]
+    for index, env in enumerate(envs):
+        env.reset(seed=seed + index if seed is not None else None)
+    setup_seconds = time.perf_counter() - setup_started_at
+
+    rgb_outputs = [
+        np.empty(SCREEN_SHAPE_24_BIT, dtype=np.uint8)
+        for _ in range(env_count)
+    ]
+    gray_outputs = [
+        np.empty(SCREEN_SHAPE_GRAYSCALE, dtype=np.uint8)
+        for _ in range(env_count)
+    ]
+    ram_outputs = [
+        np.empty((len(normalize_ram_read_specs(ram_specs)[0]),),
+                 dtype=np.uint32)
+        for _ in range(env_count)
+    ]
+    rng = np.random.RandomState(seed)
+    total = steps + warmup_steps
+    checksum = 0
+    observation_seconds = 0.0
+    ram_info_seconds = 0.0
+    native_step_seconds = 0.0
+    started_at = None
+    teardown_seconds = 0.0
+
+    try:
+        for step_number in range(1, total + 1):
+            if step_number == warmup_steps + 1:
+                started_at = time.perf_counter()
+            measured_step = step_number > warmup_steps
+            actions = _vector_action_array(
+                action_policy,
+                env_count,
+                step_number,
+                rng,
+            )
+            step_started_at = time.perf_counter()
+            for index, env in enumerate(envs):
+                env.step(int(actions[index]))
+            step_elapsed = time.perf_counter() - step_started_at
+            if measured_step:
+                native_step_seconds += step_elapsed
+
+            if observation_mode == 'native_rgb_contiguous':
+                observed_at = time.perf_counter()
+                for index, env in enumerate(envs):
+                    output = env.observation(
+                        OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+                        output=rgb_outputs[index],
+                    )
+                    if measured_step:
+                        checksum ^= _consume_observation_output(output)
+                observed_elapsed = time.perf_counter() - observed_at
+                if measured_step:
+                    observation_seconds += observed_elapsed
+            elif observation_mode == 'native_grayscale':
+                observed_at = time.perf_counter()
+                for index, env in enumerate(envs):
+                    output = env.observation(
+                        OBSERVATION_MODE_GRAYSCALE,
+                        output=gray_outputs[index],
+                    )
+                    if measured_step:
+                        checksum ^= _consume_observation_output(output)
+                observed_elapsed = time.perf_counter() - observed_at
+                if measured_step:
+                    observation_seconds += observed_elapsed
+            elif observation_mode == 'ram_info':
+                ram_at = time.perf_counter()
+                for index, env in enumerate(envs):
+                    output = env.ram_values(
+                        ram_specs,
+                        output=ram_outputs[index],
+                    )
+                    if measured_step:
+                        checksum ^= int(output[0]) if len(output) else 0
+                ram_elapsed = time.perf_counter() - ram_at
+                if measured_step:
+                    ram_info_seconds += ram_elapsed
+    finally:
+        teardown_started_at = time.perf_counter()
+        for env in envs:
+            env.close()
+        teardown_seconds = time.perf_counter() - teardown_started_at
+
+    elapsed = time.perf_counter() - started_at
+    measured_frames = steps * env_count
+    accounted = native_step_seconds + observation_seconds + ram_info_seconds
+    return VectorBenchmarkResult(
+        environment=_environment_name(),
+        compiler=_compiler_name(),
+        platform=platform_module.platform(),
+        rom=rom,
+        backend='scalar_loop',
+        env_count=env_count,
+        observation_mode=observation_mode,
+        action_policy=action_policy,
+        total_steps=total,
+        warmup_steps=warmup_steps,
+        measured_frames=measured_frames,
+        elapsed_seconds=elapsed,
+        frames_per_second=measured_frames / elapsed if elapsed > 0 else 0.0,
+        instrumentation_enabled=False,
+        cpu_affinity=cpu_affinity,
+        setup_seconds=setup_seconds,
+        native_step_seconds=native_step_seconds,
+        observation_seconds=observation_seconds,
+        ram_info_seconds=ram_info_seconds,
+        python_overhead_seconds=max(0.0, elapsed - accounted),
+        teardown_seconds=teardown_seconds,
+        checksum=checksum,
+    )
+
+
+def _make_env_factory(rom):
+    """Return a top-level-friendly factory for Gymnasium vector envs."""
+    return _NESEnvFactory(rom)
+
+
+def _measure_gym_vector_loop(
+    rom,
+    backend,
+    env_count,
+    steps,
+    warmup_steps,
+    seed,
+    action_policy,
+    observation_mode,
+    cpu_affinity,
+):
+    """Measure Gymnasium SyncVectorEnv or AsyncVectorEnv throughput."""
+    setup_started_at = time.perf_counter()
+    factories = [_make_env_factory(rom) for _ in range(env_count)]
+    vector_cls = (
+        gym.vector.AsyncVectorEnv
+        if backend == 'gym_async_vector_env'
+        else gym.vector.SyncVectorEnv
+    )
+    env = vector_cls(factories)
+    env.reset(seed=seed)
+    setup_seconds = time.perf_counter() - setup_started_at
+
+    rng = np.random.RandomState(seed)
+    total = steps + warmup_steps
+    checksum = 0
+    observation_seconds = 0.0
+    native_step_seconds = 0.0
+    started_at = None
+    teardown_seconds = 0.0
+
+    try:
+        for step_number in range(1, total + 1):
+            if step_number == warmup_steps + 1:
+                started_at = time.perf_counter()
+            measured_step = step_number > warmup_steps
+            actions = _vector_action_array(
+                action_policy,
+                env_count,
+                step_number,
+                rng,
+            )
+            step_started_at = time.perf_counter()
+            observations, _, _, _, _ = env.step(actions)
+            step_elapsed = time.perf_counter() - step_started_at
+            if measured_step:
+                native_step_seconds += step_elapsed
+            if observation_mode == 'native_rgb_contiguous':
+                observed_at = time.perf_counter()
+                output = np.ascontiguousarray(observations)
+                observed_elapsed = time.perf_counter() - observed_at
+                if measured_step:
+                    checksum ^= _consume_observation_output(output)
+                    observation_seconds += observed_elapsed
+            elif observation_mode == 'native_grayscale':
+                observed_at = time.perf_counter()
+                output = _python_grayscale(observations)
+                observed_elapsed = time.perf_counter() - observed_at
+                if measured_step:
+                    checksum ^= _consume_observation_output(output)
+                    observation_seconds += observed_elapsed
+            else:
+                if measured_step:
+                    checksum = _consume_vector_observation(
+                        observation_mode,
+                        observations,
+                        checksum,
+                    )
+    finally:
+        teardown_started_at = time.perf_counter()
+        env.close()
+        teardown_seconds = time.perf_counter() - teardown_started_at
+
+    elapsed = time.perf_counter() - started_at
+    measured_frames = steps * env_count
+    accounted = native_step_seconds + observation_seconds
+    return VectorBenchmarkResult(
+        environment=_environment_name(),
+        compiler=_compiler_name(),
+        platform=platform_module.platform(),
+        rom=rom,
+        backend=backend,
+        env_count=env_count,
+        observation_mode=observation_mode,
+        action_policy=action_policy,
+        total_steps=total,
+        warmup_steps=warmup_steps,
+        measured_frames=measured_frames,
+        elapsed_seconds=elapsed,
+        frames_per_second=measured_frames / elapsed if elapsed > 0 else 0.0,
+        instrumentation_enabled=False,
+        cpu_affinity=cpu_affinity,
+        setup_seconds=setup_seconds,
+        native_step_seconds=native_step_seconds,
+        observation_seconds=observation_seconds,
+        python_overhead_seconds=max(0.0, elapsed - accounted),
+        teardown_seconds=teardown_seconds,
+        checksum=checksum,
+    )
+
+
+def _measure_native_vector_loop(
+    rom,
+    env_count,
+    steps,
+    warmup_steps,
+    seed,
+    action_policy,
+    observation_mode,
+    ram_specs,
+    instrumentation_enabled,
+    cpu_affinity,
+):
+    """Measure the native vector emulator prototype."""
+    setup_started_at = time.perf_counter()
+    env = VectorNESEmulator(rom, env_count)
+    env.reset(seed=seed)
+    setup_seconds = time.perf_counter() - setup_started_at
+
+    rgb_output = np.empty(
+        (env_count, SCREEN_SHAPE_24_BIT[0], SCREEN_SHAPE_24_BIT[1], 3),
+        dtype=np.uint8,
+    )
+    gray_output = np.empty(
+        (env_count, SCREEN_SHAPE_GRAYSCALE[0], SCREEN_SHAPE_GRAYSCALE[1]),
+        dtype=np.uint8,
+    )
+    ram_output = np.empty(
+        (env_count, len(normalize_ram_read_specs(ram_specs)[0])),
+        dtype=np.uint32,
+    )
+    rng = np.random.RandomState(seed)
+    total = steps + warmup_steps
+    checksum = 0
+    action_transfer_seconds = 0.0
+    native_step_seconds = 0.0
+    observation_seconds = 0.0
+    ram_info_seconds = 0.0
+    python_overhead_seconds = 0.0
+    started_at = None
+    teardown_seconds = 0.0
+
+    try:
+        for step_number in range(1, total + 1):
+            if step_number == warmup_steps + 1:
+                started_at = time.perf_counter()
+            measured_step = step_number > warmup_steps
+            actions = _vector_action_array(
+                action_policy,
+                env_count,
+                step_number,
+                rng,
+            )
+            if instrumentation_enabled:
+                timing = env.step_timed(actions)
+                if measured_step:
+                    action_transfer_seconds += timing.action_transfer_seconds
+                    native_step_seconds += timing.native_step_seconds
+                    python_overhead_seconds += timing.python_overhead_seconds
+            else:
+                step_started_at = time.perf_counter()
+                env.step(actions)
+                step_elapsed = time.perf_counter() - step_started_at
+                if measured_step:
+                    native_step_seconds += step_elapsed
+
+            if observation_mode == 'native_rgb_contiguous':
+                observed_at = time.perf_counter()
+                output = env.observation(
+                    OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+                    output=rgb_output,
+                )
+                observed_elapsed = time.perf_counter() - observed_at
+                if measured_step:
+                    checksum ^= _consume_observation_output(output)
+                    observation_seconds += observed_elapsed
+            elif observation_mode == 'native_grayscale':
+                observed_at = time.perf_counter()
+                output = env.observation(
+                    OBSERVATION_MODE_GRAYSCALE,
+                    output=gray_output,
+                )
+                observed_elapsed = time.perf_counter() - observed_at
+                if measured_step:
+                    checksum ^= _consume_observation_output(output)
+                    observation_seconds += observed_elapsed
+            elif observation_mode == 'ram_info':
+                ram_at = time.perf_counter()
+                output = env.ram_values(ram_specs, output=ram_output)
+                ram_elapsed = time.perf_counter() - ram_at
+                if measured_step:
+                    checksum ^= int(output[0, 0]) if output.size else 0
+                    ram_info_seconds += ram_elapsed
+            else:
+                if measured_step:
+                    checksum = _consume_vector_observation(
+                        observation_mode,
+                        env.screens,
+                        checksum,
+                    )
+    finally:
+        teardown_started_at = time.perf_counter()
+        env.close()
+        teardown_seconds = time.perf_counter() - teardown_started_at
+
+    elapsed = time.perf_counter() - started_at
+    measured_frames = steps * env_count
+    accounted = (
+        action_transfer_seconds +
+        native_step_seconds +
+        observation_seconds +
+        ram_info_seconds +
+        python_overhead_seconds
+    )
+    if not instrumentation_enabled:
+        python_overhead_seconds = max(0.0, elapsed - accounted)
+    return VectorBenchmarkResult(
+        environment=_environment_name(),
+        compiler=_compiler_name(),
+        platform=platform_module.platform(),
+        rom=rom,
+        backend='native_vector',
+        env_count=env_count,
+        observation_mode=observation_mode,
+        action_policy=action_policy,
+        total_steps=total,
+        warmup_steps=warmup_steps,
+        measured_frames=measured_frames,
+        elapsed_seconds=elapsed,
+        frames_per_second=measured_frames / elapsed if elapsed > 0 else 0.0,
+        instrumentation_enabled=instrumentation_enabled,
+        cpu_affinity=cpu_affinity,
+        setup_seconds=setup_seconds,
+        action_transfer_seconds=action_transfer_seconds,
+        native_step_seconds=native_step_seconds,
+        synchronization_seconds=0.0,
+        observation_seconds=observation_seconds,
+        ram_info_seconds=ram_info_seconds,
+        python_overhead_seconds=python_overhead_seconds,
+        teardown_seconds=teardown_seconds,
+        worker_stats=(),
+        checksum=checksum,
+    )
+
+
+def run_vector_profile(
+    rom,
+    steps=5000,
+    warmup_steps=0,
+    seed=None,
+    action_policy='random',
+    env_counts=None,
+    observation_modes=None,
+    backends=None,
+    ram_specs=None,
+    runs=1,
+    instrumentation=False,
+    cpu_affinity='none',
+):
+    """Run repeated scalar, Gymnasium, and native vector throughput profiles."""
+    if steps <= 0:
+        raise ValueError('steps must be positive')
+    _validate_non_negative('warmup_steps', warmup_steps)
+    if runs <= 0:
+        raise ValueError('runs must be positive')
+    if cpu_affinity not in {'none', 'round_robin'}:
+        raise ValueError('cpu_affinity must be none or round_robin')
+    if env_counts is None:
+        env_counts = (1, 2, 4, 8, 16)
+    if observation_modes is None:
+        observation_modes = VECTOR_PROFILE_OBSERVATIONS
+    if backends is None:
+        backends = VECTOR_PROFILE_BACKENDS
+    if ram_specs is None:
+        ram_specs = _default_ram_read_specs()
+
+    results = []
+    for env_count in env_counts:
+        if env_count <= 0:
+            raise ValueError('env counts must be positive')
+        for observation_mode in observation_modes:
+            if observation_mode not in VECTOR_PROFILE_OBSERVATIONS:
+                raise ValueError('unknown vector observation mode: {}'.format(
+                    observation_mode
+                ))
+            for backend in backends:
+                if backend not in VECTOR_PROFILE_BACKENDS:
+                    raise ValueError('unknown vector backend: {}'.format(
+                        backend
+                    ))
+                if backend in {
+                    'gym_sync_vector_env',
+                    'gym_async_vector_env',
+                } and observation_mode == 'ram_info':
+                    continue
+                for _ in range(runs):
+                    try:
+                        if backend == 'scalar_loop':
+                            result = _measure_scalar_vector_loop(
+                                rom,
+                                env_count,
+                                steps,
+                                warmup_steps,
+                                seed,
+                                action_policy,
+                                observation_mode,
+                                ram_specs,
+                                instrumentation,
+                                cpu_affinity,
+                            )
+                        elif backend in {
+                            'gym_sync_vector_env',
+                            'gym_async_vector_env',
+                        }:
+                            result = _measure_gym_vector_loop(
+                                rom,
+                                backend,
+                                env_count,
+                                steps,
+                                warmup_steps,
+                                seed,
+                                action_policy,
+                                observation_mode,
+                                cpu_affinity,
+                            )
+                        else:
+                            result = _measure_native_vector_loop(
+                                rom,
+                                env_count,
+                                steps,
+                                warmup_steps,
+                                seed,
+                                action_policy,
+                                observation_mode,
+                                ram_specs,
+                                instrumentation,
+                                cpu_affinity,
+                            )
+                    except (AttributeError, RuntimeError, OSError):
+                        if backend == 'gym_async_vector_env':
+                            continue
+                        raise
+                    results.append(result)
+    return results
+
+
 def format_result(result):
     """Return human-readable benchmark output."""
     lines = [
@@ -542,6 +1358,32 @@ def format_observation_profile(results):
     return '\n'.join(lines)
 
 
+def format_ram_profile(results):
+    """Return human-readable RAM profile output."""
+    lines = ['NES RAM benchmark profile']
+    for result in results:
+        lines.append(
+            '  {operation}: {steps_per_second:.2f} steps/s '
+            '({elapsed_seconds:.6f}s, reads={ram_read_count}, '
+            'checksum={checksum})'.format(**result.to_dict())
+        )
+    return '\n'.join(lines)
+
+
+def format_vector_profile(results):
+    """Return human-readable vector profile output."""
+    lines = ['NES vector benchmark profile']
+    for result in results:
+        lines.append(
+            '  {backend} envs={env_count} mode={observation_mode}: '
+            '{frames_per_second:.2f} frames/s '
+            '({elapsed_seconds:.6f}s, checksum={checksum})'.format(
+                **result.to_dict()
+            )
+        )
+    return '\n'.join(lines)
+
+
 def _parser():
     """Build the command line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -566,6 +1408,50 @@ def _parser():
         action='store_true',
         help='benchmark step plus ML-style observation consumption modes',
     )
+    parser.add_argument(
+        '--ram-profile',
+        action='store_true',
+        help='benchmark wrapper-style RAM/info collection modes',
+    )
+    parser.add_argument(
+        '--vector-profile',
+        action='store_true',
+        help='benchmark scalar, Gymnasium, and native vector throughput',
+    )
+    parser.add_argument(
+        '--runs',
+        type=int,
+        default=1,
+        help='number of repeated benchmark runs to emit',
+    )
+    parser.add_argument(
+        '--env-counts',
+        default='1,2,4,8,16',
+        help='comma-separated vector environment counts',
+    )
+    parser.add_argument(
+        '--vector-backend',
+        action='append',
+        choices=VECTOR_PROFILE_BACKENDS,
+        help='vector backend to include; may be repeated',
+    )
+    parser.add_argument(
+        '--vector-observation',
+        action='append',
+        choices=VECTOR_PROFILE_OBSERVATIONS,
+        help='vector observation/profile mode to include; may be repeated',
+    )
+    parser.add_argument(
+        '--instrumentation',
+        action='store_true',
+        help='emit vector timing breakdowns when supported',
+    )
+    parser.add_argument(
+        '--cpu-affinity',
+        choices=('none', 'round_robin'),
+        default='none',
+        help='record an explicit CPU affinity experiment mode',
+    )
     parser.add_argument('--json', action='store_true', dest='json_output')
     parser.add_argument('--no-progress', action='store_false', dest='progress')
     parser.add_argument('--backup-interval', type=int)
@@ -579,11 +1465,19 @@ def main(argv=None):
     parser = _parser()
     args = parser.parse_args(argv)
 
+    profile_count = sum((
+        bool(args.observation_profile),
+        bool(args.ram_profile),
+        bool(args.vector_profile),
+        bool(args.profile_rom),
+    ))
+    if profile_count > 1:
+        parser.error(
+            'choose only one of --observation-profile, --ram-profile, '
+            '--vector-profile, or --profile-rom'
+        )
+
     if args.observation_profile:
-        if args.profile_rom:
-            parser.error(
-                '--observation-profile cannot be combined with --profile-rom'
-            )
         if args.rom is None:
             parser.error(
                 '--rom is required when --observation-profile is provided'
@@ -606,6 +1500,68 @@ def main(argv=None):
             ))
         else:
             print(format_observation_profile(results))
+        return 0
+
+    if args.ram_profile:
+        if args.rom is None:
+            parser.error('--rom is required when --ram-profile is provided')
+        try:
+            results = []
+            for _ in range(args.runs):
+                results.extend(run_ram_profile(
+                    args.rom,
+                    steps=args.steps,
+                    warmup_steps=args.warmup_steps,
+                    seed=args.seed,
+                    action_policy=args.action_policy,
+                ))
+        except KeyboardInterrupt:
+            return 130
+
+        if args.json_output:
+            print(json.dumps(
+                [result.to_dict() for result in results],
+                sort_keys=True,
+            ))
+        else:
+            print(format_ram_profile(results))
+        return 0
+
+    if args.vector_profile:
+        if args.rom is None:
+            parser.error('--rom is required when --vector-profile is provided')
+        try:
+            env_counts = tuple(
+                int(value)
+                for value in args.env_counts.split(',')
+                if value.strip()
+            )
+        except ValueError:
+            parser.error('--env-counts must be comma-separated integers')
+        try:
+            results = run_vector_profile(
+                args.rom,
+                steps=args.steps,
+                warmup_steps=args.warmup_steps,
+                seed=args.seed,
+                action_policy=args.action_policy,
+                env_counts=env_counts,
+                observation_modes=args.vector_observation,
+                backends=args.vector_backend,
+                runs=args.runs,
+                instrumentation=args.instrumentation,
+                cpu_affinity=args.cpu_affinity,
+            )
+        except KeyboardInterrupt:
+            return 130
+
+        if args.json_output:
+            print(json.dumps(
+                [result.to_dict() for result in results],
+                sort_keys=True,
+            ))
+        else:
+            print(format_vector_profile(results))
         return 0
 
     if args.profile_rom:

--- a/nes_py/speedtest.py
+++ b/nes_py/speedtest.py
@@ -14,9 +14,21 @@ from tqdm import tqdm
 
 from ._rom import ROM
 from .nes_env import NESEnv
+from .nes_env import OBSERVATION_MODE_GRAYSCALE
+from .nes_env import OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS
+from .nes_env import SCREEN_SHAPE_24_BIT
+from .nes_env import SCREEN_SHAPE_GRAYSCALE
 
 
 ActionPolicy = Callable[[NESEnv, int, np.random.RandomState], int] | str
+OBSERVATION_PROFILE_OPERATIONS = (
+    'step',
+    'step_copy',
+    'step_contiguous',
+    'step_python_grayscale',
+    'step_native_rgb_contiguous',
+    'step_native_grayscale',
+)
 
 
 @dataclass(frozen=True)
@@ -73,6 +85,27 @@ class MapperBenchmarkResult:
     warmup_steps: int
     elapsed_seconds: float
     steps_per_second: float
+
+    def to_dict(self):
+        """Return this result as a JSON-serializable dictionary."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ObservationBenchmarkResult:
+    """Structured result from an observation-consumption benchmark."""
+
+    environment: str
+    compiler: str
+    platform: str
+    rom: str
+    operation: str
+    action_policy: str
+    total_steps: int
+    warmup_steps: int
+    elapsed_seconds: float
+    steps_per_second: float
+    checksum: int
 
     def to_dict(self):
         """Return this result as a JSON-serializable dictionary."""
@@ -177,6 +210,78 @@ def _measure_mapper_operation(env, operation, steps, warmup_steps):
     return elapsed, steps_per_second
 
 
+def _python_grayscale(frame):
+    """Return a NumPy-computed grayscale copy for baseline profiling."""
+    return ((
+        77 * frame[..., 0].astype(np.uint16) +
+        150 * frame[..., 1].astype(np.uint16) +
+        29 * frame[..., 2].astype(np.uint16)
+    ) >> 8).astype(np.uint8)
+
+
+def _consume_observation_output(output):
+    """Consume one byte from an observation output for benchmark accounting."""
+    return int(np.asarray(output).flat[0])
+
+
+def _measure_observation_operation(
+    env,
+    operation,
+    action,
+    rng,
+    steps,
+    warmup_steps,
+    seed,
+):
+    """Measure one step-plus-observation-consumption operation."""
+    rgb_output = np.empty(SCREEN_SHAPE_24_BIT, dtype=np.uint8)
+    gray_output = np.empty(SCREEN_SHAPE_GRAYSCALE, dtype=np.uint8)
+    total = steps + warmup_steps
+    done = True
+    checksum = 0
+    resets = 0
+    started_at = None
+
+    for step_number in range(1, total + 1):
+        if done:
+            _reset(env, seed if resets == 0 else None)
+            resets += 1
+            done = False
+        if step_number == warmup_steps + 1:
+            started_at = time.perf_counter()
+
+        observation, _, done, _ = _step(env, action(env, step_number, rng))
+        if operation == 'step':
+            output = observation
+        elif operation == 'step_copy':
+            output = observation.copy()
+        elif operation == 'step_contiguous':
+            output = np.ascontiguousarray(observation)
+        elif operation == 'step_python_grayscale':
+            output = _python_grayscale(observation)
+        elif operation == 'step_native_rgb_contiguous':
+            output = env.observation(
+                OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+                output=rgb_output,
+            )
+        elif operation == 'step_native_grayscale':
+            output = env.observation(
+                OBSERVATION_MODE_GRAYSCALE,
+                output=gray_output,
+            )
+        else:
+            raise ValueError(
+                'unknown observation benchmark operation: {}'.format(
+                    operation
+                )
+            )
+        checksum ^= _consume_observation_output(output)
+
+    elapsed = time.perf_counter() - started_at
+    steps_per_second = steps / elapsed if elapsed > 0 else 0.0
+    return elapsed, steps_per_second, checksum
+
+
 def run_mapper_profile(
     roms,
     steps=50,
@@ -228,6 +333,62 @@ def run_mapper_profile(
                 elapsed_seconds=elapsed,
                 steps_per_second=steps_per_second,
             ))
+
+    return results
+
+
+def run_observation_profile(
+    rom,
+    steps=5000,
+    warmup_steps=0,
+    seed=None,
+    action_policy='random',
+    operations=None,
+):
+    """
+    Run step-plus-observation-consumption benchmarks for ML-style loops.
+
+    The default operation set compares the public zero-copy step output,
+    user-land copies, NumPy grayscale conversion, and native opt-in helpers.
+    """
+    if steps <= 0:
+        raise ValueError('steps must be positive')
+    _validate_non_negative('warmup_steps', warmup_steps)
+    if operations is None:
+        operations = OBSERVATION_PROFILE_OPERATIONS
+
+    action, action_name = _resolve_action(action_policy)
+    results = []
+    for operation in operations:
+        rng = np.random.RandomState(seed)
+        env = NESEnv(rom)
+        try:
+            elapsed, steps_per_second, checksum = (
+                _measure_observation_operation(
+                    env,
+                    operation,
+                    action,
+                    rng,
+                    steps,
+                    warmup_steps,
+                    seed,
+                )
+            )
+        finally:
+            env.close()
+        results.append(ObservationBenchmarkResult(
+            environment=_environment_name(),
+            compiler=_compiler_name(),
+            platform=platform_module.platform(),
+            rom=rom,
+            operation=operation,
+            action_policy=action_name,
+            total_steps=steps + warmup_steps,
+            warmup_steps=warmup_steps,
+            elapsed_seconds=elapsed,
+            steps_per_second=steps_per_second,
+            checksum=checksum,
+        ))
 
     return results
 
@@ -368,6 +529,19 @@ def format_mapper_profile(results):
     return '\n'.join(lines)
 
 
+def format_observation_profile(results):
+    """Return human-readable observation profile output."""
+    lines = ['NES observation benchmark profile']
+    for result in results:
+        lines.append(
+            '  {operation}: {steps_per_second:.2f} steps/s '
+            '({elapsed_seconds:.6f}s, checksum={checksum})'.format(
+                **result.to_dict()
+            )
+        )
+    return '\n'.join(lines)
+
+
 def _parser():
     """Build the command line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -387,6 +561,11 @@ def _parser():
         default='random',
     )
     parser.add_argument('--render-mode', choices=('rgb_array', 'human'))
+    parser.add_argument(
+        '--observation-profile',
+        action='store_true',
+        help='benchmark step plus ML-style observation consumption modes',
+    )
     parser.add_argument('--json', action='store_true', dest='json_output')
     parser.add_argument('--no-progress', action='store_false', dest='progress')
     parser.add_argument('--backup-interval', type=int)
@@ -399,6 +578,35 @@ def main(argv=None):
     """Run the benchmark command line interface."""
     parser = _parser()
     args = parser.parse_args(argv)
+
+    if args.observation_profile:
+        if args.profile_rom:
+            parser.error(
+                '--observation-profile cannot be combined with --profile-rom'
+            )
+        if args.rom is None:
+            parser.error(
+                '--rom is required when --observation-profile is provided'
+            )
+        try:
+            results = run_observation_profile(
+                args.rom,
+                steps=args.steps,
+                warmup_steps=args.warmup_steps,
+                seed=args.seed,
+                action_policy=args.action_policy,
+            )
+        except KeyboardInterrupt:
+            return 130
+
+        if args.json_output:
+            print(json.dumps(
+                [result.to_dict() for result in results],
+                sort_keys=True,
+            ))
+        else:
+            print(format_observation_profile(results))
+        return 0
 
     if args.profile_rom:
         try:

--- a/nes_py/tests/test_mappers.py
+++ b/nes_py/tests/test_mappers.py
@@ -1,0 +1,15 @@
+"""Compatibility entry point for the mapper unittest package."""
+
+from pathlib import Path
+
+
+def load_tests(loader, tests, pattern):
+    """Load mapper tests for ``python -m unittest nes_py.tests.test_mappers``."""
+    del tests
+    start_dir = Path(__file__).with_name('mappers')
+    top_level_dir = Path(__file__).parents[2]
+    return loader.discover(
+        str(start_dir),
+        pattern=pattern or 'test*.py',
+        top_level_dir=str(top_level_dir),
+    )

--- a/nes_py/tests/test_nes_env.py
+++ b/nes_py/tests/test_nes_env.py
@@ -7,7 +7,11 @@ import numpy as np
 
 from nes_py.tests.rom_file_abs_path import rom_file_abs_path
 from nes_py.nes_env import NESEnv
+from nes_py.nes_env import OBSERVATION_MODE_GRAYSCALE
+from nes_py.nes_env import OBSERVATION_MODE_RGB_ARRAY
+from nes_py.nes_env import OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS
 from nes_py.nes_env import SCREEN_SHAPE_24_BIT
+from nes_py.nes_env import SCREEN_SHAPE_GRAYSCALE
 
 
 USABLE_ON_DISK_ROM_NAMES = (
@@ -212,6 +216,127 @@ class ShouldExposeMutableApplicationBuffers(NESEnvApplicationAssertions):
         self.assert_native_view(ram, (0x800,))
         self.assert_native_view(controller, (1,))
         self.assertEqual(1, controller[0])
+
+
+class ShouldExposeObservationFastPaths(NESEnvApplicationAssertions):
+    """Exercise opt-in ML observation copy helpers."""
+
+    def assert_contiguous_uint8(self, array, shape):
+        """Assert an observation helper returned a C-contiguous uint8 array."""
+        self.assertIsInstance(array, np.ndarray)
+        self.assertEqual(shape, array.shape)
+        self.assertEqual(np.uint8, array.dtype)
+        self.assertTrue(array.flags.c_contiguous)
+        self.assertTrue(array.flags.writeable)
+
+    def expected_grayscale(self, frame):
+        """Return the integer luma conversion used by the native helper."""
+        return ((
+            77 * frame[..., 0].astype(np.uint16) +
+            150 * frame[..., 1].astype(np.uint16) +
+            29 * frame[..., 2].astype(np.uint16)
+        ) >> 8).astype(np.uint8)
+
+    def test_default_mode_returns_public_zero_copy_screen(self):
+        env = create_smb1_instance()
+        try:
+            self.reset_frame(env, seed=19)
+            self.assertIs(env.screen, env.observation())
+            self.assertIs(
+                env.screen,
+                env.observation(OBSERVATION_MODE_RGB_ARRAY),
+            )
+        finally:
+            env.close()
+
+    def test_copy_modes_match_current_screen_and_can_reuse_output(self):
+        env = create_smb1_instance()
+        try:
+            self.reset_frame(env, seed=19)
+            rgb_output = np.empty(SCREEN_SHAPE_24_BIT, dtype=np.uint8)
+            gray_output = np.empty(SCREEN_SHAPE_GRAYSCALE, dtype=np.uint8)
+
+            for action in (0, 8, 0):
+                env.step(action)
+                expected_rgb = np.ascontiguousarray(env.screen)
+                expected_gray = self.expected_grayscale(expected_rgb)
+
+                rgb = env.observation(
+                    OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+                    output=rgb_output,
+                )
+                gray = env.observation(
+                    OBSERVATION_MODE_GRAYSCALE,
+                    output=gray_output,
+                )
+
+                self.assertIs(rgb_output, rgb)
+                self.assertIs(gray_output, gray)
+                self.assert_contiguous_uint8(rgb, SCREEN_SHAPE_24_BIT)
+                self.assert_contiguous_uint8(gray, SCREEN_SHAPE_GRAYSCALE)
+                self.assertTrue(np.array_equal(expected_rgb, rgb))
+                self.assertTrue(np.array_equal(expected_gray, gray))
+        finally:
+            env.close()
+
+    def test_copy_modes_reset_render_and_close_behavior(self):
+        env = NESEnv(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            render_mode='rgb_array',
+        )
+        self.reset_frame(env, seed=29)
+        rgb = env.observation(OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS)
+        gray = env.observation(OBSERVATION_MODE_GRAYSCALE)
+        self.assert_contiguous_uint8(rgb, SCREEN_SHAPE_24_BIT)
+        self.assert_contiguous_uint8(gray, SCREEN_SHAPE_GRAYSCALE)
+        self.assertIs(env.screen, env.render())
+
+        env.step(0)
+        stepped_rgb = env.observation(OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS)
+        self.assertTrue(np.array_equal(np.ascontiguousarray(env.screen),
+                                       stepped_rgb))
+
+        env.reset(seed=29)
+        reset_rgb = env.observation(OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS)
+        self.assertTrue(np.array_equal(np.ascontiguousarray(env.screen),
+                                       reset_rgb))
+
+        env.close()
+        self.assert_contiguous_uint8(rgb, SCREEN_SHAPE_24_BIT)
+        self.assert_contiguous_uint8(gray, SCREEN_SHAPE_GRAYSCALE)
+        self.assertIsInstance(int(rgb[0, 0, 0]), int)
+        self.assertIsInstance(int(gray[0, 0]), int)
+        self.assertIs(env.screen, env.observation())
+        with self.assertRaises(ValueError):
+            env.observation(OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS)
+        with self.assertRaises(ValueError):
+            env.observation(OBSERVATION_MODE_GRAYSCALE)
+
+    def test_copy_modes_validate_output_and_mode(self):
+        env = create_smb1_instance()
+        try:
+            self.reset_frame(env)
+            with self.assertRaises(ValueError):
+                env.observation(
+                    OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+                    output=np.empty(SCREEN_SHAPE_GRAYSCALE, dtype=np.uint8),
+                )
+            with self.assertRaises(TypeError):
+                env.observation(
+                    OBSERVATION_MODE_GRAYSCALE,
+                    output=np.empty(SCREEN_SHAPE_GRAYSCALE, dtype=np.uint16),
+                )
+            with self.assertRaises(ValueError):
+                env.observation(
+                    OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+                    output=np.empty(SCREEN_SHAPE_24_BIT,
+                                    dtype=np.uint8,
+                                    order='F'),
+                )
+            with self.assertRaises(NotImplementedError):
+                env.observation('nearest_neighbor')
+        finally:
+            env.close()
 
 
 class ShouldReadAndWriteMemory(TestCase):

--- a/nes_py/tests/test_nes_env.py
+++ b/nes_py/tests/test_nes_env.py
@@ -26,6 +26,17 @@ USABLE_ON_DISK_ROM_NAMES = (
 UNSUPPORTED_ON_DISK_ROM_NAMES = ()
 
 DETERMINISTIC_ACTIONS = (0, 1, 2, 4, 8, 16, 32, 64)
+SNAPSHOT_MAPPER_ROM_NAMES = (
+    'super-mario-bros-1.nes',
+    'the-legend-of-zelda.nes',
+    'mega-man.nes',
+    'adventure-island.nes',
+    'super-mario-bros-3.nes',
+    'castlevania-iii-draculas-curse.nes',
+    'battletoads.nes',
+    'mike-tysons-punch-out.nes',
+    'batman-return-of-the-joker.nes',
+)
 
 
 def create_smb1_instance():
@@ -581,3 +592,58 @@ class ShouldPreservePackageBackupRestoreWorkflow(NESEnvApplicationAssertions):
                     self.assert_valid_frame(state)
         finally:
             env.close()
+
+
+class ShouldExposeOpaqueStateSnapshots(NESEnvApplicationAssertions):
+    """Exercise the public opaque snapshot API across mapper fixtures."""
+
+    def test_invalid_snapshot_input_raises_clear_error(self):
+        env = create_smb1_instance()
+        try:
+            self.reset_frame(env, seed=41)
+            with self.assertRaises(TypeError):
+                env.load_state(object())
+        finally:
+            env.close()
+
+    def test_snapshot_round_trip_restores_state_and_continuation(self):
+        setup_actions = [0, 8, 0, 8, 1, 2, 0, 4]
+        continuation_actions = [0, 1, 2, 4, 8, 16, 32, 64, 128, 255]
+        for name in SNAPSHOT_MAPPER_ROM_NAMES:
+            with self.subTest(name=name):
+                env = NESEnv(rom_file_abs_path(name))
+                try:
+                    self.reset_frame(env, seed=43)
+                    self.advance(env, setup_actions)
+                    snapshot = env.dump_state()
+                    snapshot_screen = env.screen.copy()
+                    snapshot_ram = env.ram.copy()
+
+                    expected = self.advance(env, continuation_actions)
+                    env.load_state(snapshot)
+                    self.assertTrue(np.array_equal(snapshot_screen,
+                                                   env.screen))
+                    self.assertTrue(np.array_equal(snapshot_ram, env.ram))
+
+                    actual = self.advance(env, continuation_actions)
+                    for expected_output, actual_output in zip(expected, actual):
+                        self.assertTrue(np.array_equal(
+                            expected_output[0],
+                            actual_output[0],
+                        ))
+                        self.assertEqual(expected_output[1:],
+                                         actual_output[1:])
+                finally:
+                    env.close()
+
+    def test_snapshot_after_close_raises_but_existing_snapshot_remains_opaque(self):
+        env = create_smb1_instance()
+        self.reset_frame(env, seed=47)
+        snapshot = env.dump_state()
+        env.close()
+
+        self.assertIsNotNone(snapshot)
+        with self.assertRaises(ValueError):
+            env.dump_state()
+        with self.assertRaises(ValueError):
+            env.load_state(snapshot)

--- a/nes_py/tests/test_ram_reads.py
+++ b/nes_py/tests/test_ram_reads.py
@@ -1,0 +1,124 @@
+"""Tests for generic RAM batch read helpers."""
+from unittest import TestCase
+
+import numpy as np
+
+from nes_py.nes_env import NESEnv
+from nes_py.tests.rom_file_abs_path import rom_file_abs_path
+from nes_py.vector_env import VectorNESEmulator
+
+
+def create_env():
+    """Return a reset SMB1 environment for RAM helper tests."""
+    env = NESEnv(rom_file_abs_path('super-mario-bros-1.nes'))
+    env.reset(seed=5)
+    return env
+
+
+class ShouldReadConfiguredRAMValues(TestCase):
+    """Exercise byte, integer, and digit-oriented RAM reads."""
+
+    def test_scalar_reads_values_and_reuses_output(self):
+        env = create_env()
+        try:
+            env.ram[0x10] = 7
+            env.ram[0x11] = 0x34
+            env.ram[0x12] = 0x12
+            env.ram[0x13] = 0x56
+            env.ram[0x14] = 0x78
+            env.ram[0x15] = 0x12
+            env.ram[0x16] = 0x34
+            env.ram[0x17] = 1
+            env.ram[0x18] = 2
+            env.ram[0x19] = 3
+            specs = (
+                0x10,
+                (0x11, 2, 'little'),
+                (0x13, 2, 'big'),
+                (0x15, 2, 'bcd'),
+                {'address': 0x17, 'size': 3, 'encoding': 'digits'},
+            )
+            output = np.empty((5,), dtype=np.uint32)
+
+            values = env.ram_values(specs, output=output)
+
+            self.assertIs(output, values)
+            self.assertEqual(
+                [7, 0x1234, 0x5678, 1234, 123],
+                values.tolist(),
+            )
+        finally:
+            env.close()
+
+    def test_empty_specs_return_empty_uint32_array(self):
+        env = create_env()
+        try:
+            values = env.ram_values(())
+            self.assertEqual((0,), values.shape)
+            self.assertEqual(np.uint32, values.dtype)
+        finally:
+            env.close()
+
+    def test_validates_specs_and_output(self):
+        env = create_env()
+        try:
+            for specs in (
+                (-1,),
+                (0x800,),
+                ((0x7ff, 2),),
+                ((0x10, 0),),
+                ((0x10, 2, 'byte'),),
+                ((0x10, 5, 'little'),),
+                ((0x10, 1, 'unknown'),),
+            ):
+                with self.subTest(specs=specs):
+                    with self.assertRaises((TypeError, ValueError)):
+                        env.ram_values(specs)
+            with self.assertRaises(ValueError):
+                env.ram_values((0x10,), output=np.empty((2,), dtype=np.uint32))
+            with self.assertRaises(TypeError):
+                env.ram_values((0x10,), output=np.empty((1,), dtype=np.uint8))
+            non_contiguous = np.empty((4,), dtype=np.uint32)[::2]
+            with self.assertRaises(ValueError):
+                env.ram_values(
+                    (0x10, 0x11),
+                    output=non_contiguous,
+                )
+        finally:
+            env.close()
+
+    def test_reset_restore_and_close_behavior(self):
+        env = create_env()
+        try:
+            env.ram[0x20] = 11
+            env._backup()
+            env.ram[0x20] = 99
+            self.assertEqual([99], env.ram_values((0x20,)).tolist())
+            env._restore()
+            self.assertEqual([11], env.ram_values((0x20,)).tolist())
+            env.reset(seed=5)
+            self.assertEqual((1,), env.ram_values((0x20,)).shape)
+            output = env.ram_values((0x20,))
+        finally:
+            env.close()
+
+        self.assertEqual((1,), output.shape)
+        with self.assertRaises(ValueError):
+            env.ram_values((0x20,))
+
+    def test_vector_reads_all_slots(self):
+        vector = VectorNESEmulator(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            2,
+        )
+        try:
+            vector.reset()
+            vector.rams[0][0x30] = 1
+            vector.rams[1][0x30] = 2
+            output = np.empty((2, 1), dtype=np.uint32)
+            values = vector.ram_values((0x30,), output=output)
+
+            self.assertIs(output, values)
+            self.assertEqual([[1], [2]], values.tolist())
+        finally:
+            vector.close()

--- a/nes_py/tests/test_speedtest.py
+++ b/nes_py/tests/test_speedtest.py
@@ -8,9 +8,11 @@ from unittest import TestCase
 from nes_py.tests.mapper_fixtures import synthetic_rom_path
 from nes_py.tests.rom_file_abs_path import rom_file_abs_path
 from nes_py.speedtest import BenchmarkConfig
+from nes_py.speedtest import OBSERVATION_PROFILE_OPERATIONS
 from nes_py.speedtest import main
 from nes_py.speedtest import run_benchmark
 from nes_py.speedtest import run_mapper_profile
+from nes_py.speedtest import run_observation_profile
 
 
 class ShouldRunBenchmark(TestCase):
@@ -178,5 +180,58 @@ class ShouldRunCurrentMapperBenchmarkProfile(TestCase):
         self.assertEqual(8, len(data))
         for result in data:
             self.assertIn(result['mapper'], {0, 1})
+            self.assertGreater(result['elapsed_seconds'], 0)
+            self.assertGreater(result['steps_per_second'], 0)
+
+
+class ShouldRunObservationBenchmarkProfile(TestCase):
+    def test_returns_all_observation_operations(self):
+        results = run_observation_profile(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            steps=2,
+            warmup_steps=1,
+            seed=3,
+            action_policy='noop',
+        )
+
+        self.assertEqual(len(OBSERVATION_PROFILE_OPERATIONS), len(results))
+        seen = {result.operation for result in results}
+        self.assertEqual(set(OBSERVATION_PROFILE_OPERATIONS), seen)
+        for result in results:
+            data = result.to_dict()
+            self.assertIn('environment', data)
+            self.assertIn('compiler', data)
+            self.assertIn('platform', data)
+            self.assertEqual('noop', data['action_policy'])
+            self.assertEqual(3, data['total_steps'])
+            self.assertEqual(1, data['warmup_steps'])
+            self.assertGreater(data['elapsed_seconds'], 0)
+            self.assertGreater(data['steps_per_second'], 0)
+            self.assertIsInstance(data['checksum'], int)
+
+    def test_cli_json_output(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            status = main([
+                '--rom',
+                rom_file_abs_path('super-mario-bros-1.nes'),
+                '--observation-profile',
+                '--steps',
+                '1',
+                '--warmup-steps',
+                '0',
+                '--action-policy',
+                'noop',
+                '--json',
+                '--no-progress',
+            ])
+
+        self.assertEqual(0, status)
+        data = json.loads(output.getvalue())
+        self.assertEqual(len(OBSERVATION_PROFILE_OPERATIONS), len(data))
+        seen = {result['operation'] for result in data}
+        self.assertEqual(set(OBSERVATION_PROFILE_OPERATIONS), seen)
+        for result in data:
+            self.assertEqual('noop', result['action_policy'])
             self.assertGreater(result['elapsed_seconds'], 0)
             self.assertGreater(result['steps_per_second'], 0)

--- a/nes_py/tests/test_speedtest.py
+++ b/nes_py/tests/test_speedtest.py
@@ -9,10 +9,13 @@ from nes_py.tests.mapper_fixtures import synthetic_rom_path
 from nes_py.tests.rom_file_abs_path import rom_file_abs_path
 from nes_py.speedtest import BenchmarkConfig
 from nes_py.speedtest import OBSERVATION_PROFILE_OPERATIONS
+from nes_py.speedtest import RAM_PROFILE_OPERATIONS
 from nes_py.speedtest import main
 from nes_py.speedtest import run_benchmark
 from nes_py.speedtest import run_mapper_profile
 from nes_py.speedtest import run_observation_profile
+from nes_py.speedtest import run_ram_profile
+from nes_py.speedtest import run_vector_profile
 
 
 class ShouldRunBenchmark(TestCase):
@@ -235,3 +238,120 @@ class ShouldRunObservationBenchmarkProfile(TestCase):
             self.assertEqual('noop', result['action_policy'])
             self.assertGreater(result['elapsed_seconds'], 0)
             self.assertGreater(result['steps_per_second'], 0)
+
+
+class ShouldRunRAMBenchmarkProfile(TestCase):
+    def test_returns_ram_operations(self):
+        results = run_ram_profile(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            steps=2,
+            warmup_steps=1,
+            seed=5,
+            action_policy='noop',
+        )
+
+        self.assertEqual(len(RAM_PROFILE_OPERATIONS), len(results))
+        seen = {result.operation for result in results}
+        self.assertEqual(set(RAM_PROFILE_OPERATIONS), seen)
+        for result in results:
+            data = result.to_dict()
+            self.assertEqual('noop', data['action_policy'])
+            self.assertEqual(3, data['total_steps'])
+            self.assertEqual(1, data['warmup_steps'])
+            self.assertGreater(data['ram_read_count'], 0)
+            self.assertGreater(data['elapsed_seconds'], 0)
+            self.assertGreater(data['steps_per_second'], 0)
+            self.assertIsInstance(data['checksum'], int)
+
+    def test_cli_json_output(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            status = main([
+                '--rom',
+                rom_file_abs_path('super-mario-bros-1.nes'),
+                '--ram-profile',
+                '--steps',
+                '1',
+                '--warmup-steps',
+                '0',
+                '--action-policy',
+                'noop',
+                '--json',
+                '--no-progress',
+            ])
+
+        self.assertEqual(0, status)
+        data = json.loads(output.getvalue())
+        self.assertEqual(len(RAM_PROFILE_OPERATIONS), len(data))
+        for result in data:
+            self.assertEqual('noop', result['action_policy'])
+            self.assertGreater(result['elapsed_seconds'], 0)
+            self.assertGreater(result['steps_per_second'], 0)
+
+
+class ShouldRunVectorBenchmarkProfile(TestCase):
+    def test_returns_vector_backends_modes_and_timing_fields(self):
+        results = run_vector_profile(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            steps=1,
+            warmup_steps=0,
+            seed=7,
+            action_policy='noop',
+            env_counts=(1, 2),
+            observation_modes=(
+                'step_only',
+                'native_grayscale',
+                'ram_info',
+            ),
+            backends=('scalar_loop', 'native_vector'),
+            runs=1,
+            instrumentation=True,
+        )
+
+        self.assertEqual(12, len(results))
+        seen = {
+            (result.backend, result.env_count, result.observation_mode)
+            for result in results
+        }
+        self.assertIn(('native_vector', 2, 'ram_info'), seen)
+        self.assertIn(('scalar_loop', 1, 'native_grayscale'), seen)
+        for result in results:
+            data = result.to_dict()
+            self.assertIn(data['backend'], {'scalar_loop', 'native_vector'})
+            self.assertIn(data['env_count'], {1, 2})
+            self.assertGreater(data['elapsed_seconds'], 0)
+            self.assertGreater(data['frames_per_second'], 0)
+            self.assertIn('native_step_seconds', data)
+            self.assertIn('python_overhead_seconds', data)
+            self.assertIn('worker_stats', data)
+
+    def test_cli_json_output(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            status = main([
+                '--rom',
+                rom_file_abs_path('super-mario-bros-1.nes'),
+                '--vector-profile',
+                '--steps',
+                '1',
+                '--warmup-steps',
+                '0',
+                '--action-policy',
+                'noop',
+                '--env-counts',
+                '1',
+                '--vector-backend',
+                'native_vector',
+                '--vector-observation',
+                'step_only',
+                '--instrumentation',
+                '--json',
+                '--no-progress',
+            ])
+
+        self.assertEqual(0, status)
+        data = json.loads(output.getvalue())
+        self.assertEqual(1, len(data))
+        self.assertEqual('native_vector', data[0]['backend'])
+        self.assertEqual('step_only', data[0]['observation_mode'])
+        self.assertTrue(data[0]['instrumentation_enabled'])

--- a/nes_py/tests/test_vector_env.py
+++ b/nes_py/tests/test_vector_env.py
@@ -1,0 +1,149 @@
+"""Tests for the opt-in native vector emulator."""
+from unittest import TestCase
+
+import numpy as np
+
+from nes_py.nes_env import NESEnv
+from nes_py.nes_env import OBSERVATION_MODE_GRAYSCALE
+from nes_py.nes_env import OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS
+from nes_py.nes_env import SCREEN_SHAPE_24_BIT
+from nes_py.nes_env import SCREEN_SHAPE_GRAYSCALE
+from nes_py.tests.rom_file_abs_path import rom_file_abs_path
+from nes_py.vector_env import VectorNESEmulator
+
+
+REPRESENTATIVE_MAPPER_ROMS = (
+    'super-mario-bros-1.nes',
+    'the-legend-of-zelda.nes',
+    'mega-man.nes',
+    'adventure-island.nes',
+    'super-mario-bros-3.nes',
+    'castlevania-iii-draculas-curse.nes',
+    'battletoads.nes',
+    'mike-tysons-punch-out.nes',
+    'batman-return-of-the-joker.nes',
+)
+
+
+class ShouldRunNativeVectorEmulator(TestCase):
+    """Exercise vector construction, stepping, buffers, and close semantics."""
+
+    def test_construct_reset_step_reset_one_and_close(self):
+        vector = VectorNESEmulator(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            3,
+        )
+        try:
+            self.assertEqual(3, vector.num_envs)
+            observations = vector.reset()
+            self.assertEqual(3, len(observations))
+            for screen, ram in zip(vector.screens, vector.rams):
+                self.assertEqual(SCREEN_SHAPE_24_BIT, screen.shape)
+                self.assertEqual((0x800,), ram.shape)
+
+            vector.step(np.array([0, 1, 2], dtype=np.uint8))
+            vector.reset_one(1)
+            one = vector.step_one(1, 8)
+            self.assertEqual(SCREEN_SHAPE_24_BIT, one.shape)
+        finally:
+            screen = vector.screens[0]
+            ram = vector.rams[0]
+            vector.close()
+
+        self.assertEqual(SCREEN_SHAPE_24_BIT, screen.shape)
+        self.assertEqual((0x800,), ram.shape)
+        with self.assertRaises(ValueError):
+            vector.step(np.array([0, 0, 0], dtype=np.uint8))
+        self.assertEqual(3, len(vector.observation()))
+
+    def test_copy_observation_modes_can_reuse_output(self):
+        vector = VectorNESEmulator(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            2,
+        )
+        try:
+            vector.reset()
+            vector.step(np.array([0, 8], dtype=np.uint8))
+            rgb = np.empty((2,) + SCREEN_SHAPE_24_BIT, dtype=np.uint8)
+            gray = np.empty((2,) + SCREEN_SHAPE_GRAYSCALE, dtype=np.uint8)
+
+            rgb_result = vector.observation(
+                OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+                output=rgb,
+            )
+            gray_result = vector.observation(
+                OBSERVATION_MODE_GRAYSCALE,
+                output=gray,
+            )
+
+            self.assertIs(rgb, rgb_result)
+            self.assertIs(gray, gray_result)
+            self.assertEqual((2,) + SCREEN_SHAPE_24_BIT, rgb.shape)
+            self.assertEqual((2,) + SCREEN_SHAPE_GRAYSCALE, gray.shape)
+            self.assertTrue(np.array_equal(
+                np.ascontiguousarray(vector.screens[0]),
+                rgb[0],
+            ))
+            self.assertEqual(np.uint8, gray.dtype)
+        finally:
+            vector.close()
+
+    def test_invalid_inputs_raise_clear_errors(self):
+        vector = VectorNESEmulator(
+            rom_file_abs_path('super-mario-bros-1.nes'),
+            2,
+        )
+        try:
+            with self.assertRaises(ValueError):
+                vector.step(np.zeros((2, 1), dtype=np.uint8))
+            with self.assertRaises(TypeError):
+                vector.step(np.array([0, 1], dtype=np.int64))
+            with self.assertRaises(ValueError):
+                vector.step(np.array([0], dtype=np.uint8))
+            with self.assertRaises(IndexError):
+                vector.reset_one(2)
+            with self.assertRaises(IndexError):
+                vector.observation_one(-1)
+            with self.assertRaises(NotImplementedError):
+                vector.observation('nearest_neighbor')
+        finally:
+            vector.close()
+
+        with self.assertRaises(ValueError):
+            VectorNESEmulator(rom_file_abs_path('missing.nes'), 2)
+        with self.assertRaises(ValueError):
+            VectorNESEmulator(rom_file_abs_path('super-mario-bros-1.nes'), 0)
+
+    def test_vector_steps_match_scalar_envs_for_representative_mappers(self):
+        actions = (
+            np.array([0, 1, 2], dtype=np.uint8),
+            np.array([4, 8, 16], dtype=np.uint8),
+            np.array([32, 64, 128], dtype=np.uint8),
+            np.array([255, 0, 8], dtype=np.uint8),
+        )
+        for name in REPRESENTATIVE_MAPPER_ROMS:
+            with self.subTest(name=name):
+                rom = rom_file_abs_path(name)
+                scalars = [NESEnv(rom) for _ in range(3)]
+                vector = VectorNESEmulator(rom, 3)
+                try:
+                    for scalar in scalars:
+                        scalar.reset(seed=31)
+                    vector.reset(seed=31)
+
+                    for action_row in actions:
+                        vector.step(action_row)
+                        for index, scalar in enumerate(scalars):
+                            scalar.step(int(action_row[index]))
+                            self.assertTrue(np.array_equal(
+                                scalar.screen,
+                                vector.screens[index],
+                            ))
+                            self.assertTrue(np.array_equal(
+                                scalar.ram,
+                                vector.rams[index],
+                            ))
+                finally:
+                    for scalar in scalars:
+                        scalar.close()
+                    vector.close()

--- a/nes_py/vector_env.py
+++ b/nes_py/vector_env.py
@@ -1,0 +1,214 @@
+"""Opt-in native vector emulator helpers for same-ROM NES workloads."""
+import time
+from dataclasses import asdict
+from dataclasses import dataclass
+
+import numpy as np
+from gymnasium.spaces import Box
+from gymnasium.spaces import Discrete
+
+from . import _native
+from ._rom import ROM
+from .nes_env import OBSERVATION_MODE_GRAYSCALE
+from .nes_env import OBSERVATION_MODE_RGB_ARRAY
+from .nes_env import OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS
+from .nes_env import SCREEN_SHAPE_24_BIT
+from .nes_env import SCREEN_SHAPE_GRAYSCALE
+from .nes_env import _is_mapper_supported
+from .ram import normalize_ram_read_specs
+
+
+@dataclass(frozen=True)
+class VectorStepTiming:
+    """Timing counters for one vector step call."""
+
+    python_overhead_seconds: float
+    action_transfer_seconds: float
+    native_step_seconds: float
+    synchronization_seconds: float
+    observation_seconds: float = 0.0
+    ram_info_seconds: float = 0.0
+    worker_stats: tuple = ()
+
+    def to_dict(self):
+        """Return this timing result as a JSON-serializable dictionary."""
+        return asdict(self)
+
+
+def _validate_rom(rom_path):
+    """Apply the same generic ROM checks used by ``NESEnv``."""
+    rom = ROM(rom_path)
+    if rom.prg_rom_size == 0:
+        raise ValueError('ROM has no PRG-ROM banks.')
+    if rom.has_trainer:
+        raise ValueError('ROM has trainer. trainer is not supported.')
+    _ = rom.prg_rom
+    _ = rom.chr_rom
+    if rom.is_pal:
+        raise ValueError('ROM is PAL. PAL is not supported.')
+    if not _is_mapper_supported(rom.mapper):
+        msg = (
+            'ROM has an unsupported mapper number {}. please see '
+            'https://github.com/Kautenja/nes-py/issues/28 for more '
+            'information.'
+        )
+        raise ValueError(msg.format(rom.mapper))
+
+
+class VectorNESEmulator:
+    """
+    Same-ROM native vector emulator.
+
+    This class intentionally keeps game-specific reward, termination, and info
+    logic out of ``nes-py``. It batches controller writes, frame advances,
+    observation copies, RAM reads, resets, and opaque state snapshots for
+    wrapper or training-loop code that already owns those semantics.
+    """
+
+    action_space = Discrete(256)
+    observation_space = Box(
+        low=0,
+        high=255,
+        shape=SCREEN_SHAPE_24_BIT,
+        dtype=np.uint8,
+    )
+
+    def __init__(self, rom_path, env_count):
+        """Create ``env_count`` native emulator instances for one ROM."""
+        _validate_rom(rom_path)
+        self.rom_path = rom_path
+        self.num_envs = int(env_count)
+        if self.num_envs <= 0:
+            raise ValueError('env_count must be positive')
+        self._native = _native.NativeVectorEmulator(rom_path, self.num_envs)
+        self.screens = tuple(
+            self._native.screen_buffer(index)
+            for index in range(self.num_envs)
+        )
+        self.rams = tuple(
+            self._native.ram_buffer(index)
+            for index in range(self.num_envs)
+        )
+
+    def _require_open(self):
+        """Raise if the native vector emulator is closed."""
+        if self._native is None:
+            raise ValueError('vector emulator has already been closed.')
+
+    def close(self):
+        """Close native operations while existing buffer views remain valid."""
+        self._require_open()
+        self._native.close()
+        self._native = None
+
+    def reset(self, *, seed=None):
+        """Reset all vector slots and return the zero-copy screen views."""
+        del seed
+        self._require_open()
+        self._native.reset()
+        return self.observation()
+
+    def reset_one(self, index):
+        """Reset one vector slot and return its zero-copy screen view."""
+        self._require_open()
+        self._native.reset_one(index)
+        return self.screens[int(index)]
+
+    def step(self, actions):
+        """Step all vector slots with a one-dimensional uint8 action array."""
+        self._require_open()
+        self._native.step(actions)
+        return self.observation()
+
+    def step_timed(self, actions):
+        """Step all vector slots and return timing counters."""
+        self._require_open()
+        started_at = time.perf_counter()
+        array = np.asarray(actions)
+        transferred_at = time.perf_counter()
+        self._native.step(array)
+        stepped_at = time.perf_counter()
+        native_seconds = stepped_at - transferred_at
+        total_seconds = stepped_at - started_at
+        action_seconds = transferred_at - started_at
+        return VectorStepTiming(
+            python_overhead_seconds=max(
+                0.0,
+                total_seconds - native_seconds - action_seconds,
+            ),
+            action_transfer_seconds=action_seconds,
+            native_step_seconds=native_seconds,
+            synchronization_seconds=0.0,
+            worker_stats=(),
+        )
+
+    def step_one(self, index, action):
+        """Step one vector slot and return its zero-copy screen view."""
+        self._require_open()
+        self._native.step_one(index, action)
+        return self.screens[int(index)]
+
+    def observation(self, mode=OBSERVATION_MODE_RGB_ARRAY, output=None):
+        """Return vector observations using zero-copy or native copy modes."""
+        if mode == OBSERVATION_MODE_RGB_ARRAY:
+            return self.screens
+        self._require_open()
+        if mode == OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS:
+            return self._native.copy_screen_rgb_batch(output)
+        if mode == OBSERVATION_MODE_GRAYSCALE:
+            return self._native.copy_screen_grayscale_batch(output)
+        modes = (
+            OBSERVATION_MODE_RGB_ARRAY,
+            OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS,
+            OBSERVATION_MODE_GRAYSCALE,
+        )
+        msg = 'valid observation modes are: {}'.format(
+            ', '.join(repr(mode) for mode in modes)
+        )
+        raise NotImplementedError(msg)
+
+    def observation_one(
+        self,
+        index,
+        mode=OBSERVATION_MODE_RGB_ARRAY,
+        output=None,
+    ):
+        """Return one vector slot observation."""
+        env_index = int(index)
+        if env_index < 0 or env_index >= self.num_envs:
+            raise IndexError('env index out of range')
+        if mode == OBSERVATION_MODE_RGB_ARRAY:
+            return self.screens[env_index]
+        self._require_open()
+        if mode == OBSERVATION_MODE_RGB_ARRAY_CONTIGUOUS:
+            return self._native.copy_screen_rgb(index, output)
+        if mode == OBSERVATION_MODE_GRAYSCALE:
+            return self._native.copy_screen_grayscale(index, output)
+        raise NotImplementedError('unknown observation mode: {}'.format(mode))
+
+    def ram_values(self, specs, output=None):
+        """Read configured RAM values for every vector slot."""
+        self._require_open()
+        addresses, sizes, encodings = normalize_ram_read_specs(specs)
+        return self._native.read_ram_values(
+            addresses,
+            sizes,
+            encodings,
+            output,
+        )
+
+    def dump_state(self, index):
+        """Return an opaque state snapshot for one vector slot."""
+        self._require_open()
+        return self._native.dump_state(index)
+
+    def load_state(self, index, snapshot):
+        """Restore one vector slot from an opaque state snapshot."""
+        self._require_open()
+        self._native.load_state(index, snapshot)
+
+
+__all__ = [
+    'VectorNESEmulator',
+    'VectorStepTiming',
+]


### PR DESCRIPTION
## Summary

- Adds PPU sprite/background batching, mapper direct-read paths, ML observation helpers, and CPU instruction batching.
- Adds native vector emulator, batch RAM reads, and explicit state snapshot APIs.
- Documents native runtime troubleshooting and restores MMC3 background tile caching behavior.

## Validation

Focused Python, native, benchmark, and packaging checks are recorded in the branch completion logs for the related work items.

## Notes

This PR targets `master` from the pushed `p90` branch.