### PR TITLE
[codex] Fix release artifact upload repo context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           gh release view "$TAG_NAME" || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Automated release for $TAG_NAME"


### PR DESCRIPTION
## Summary

Set `GH_REPO` in the tag release artifact job so GitHub CLI release commands can resolve the repository even though the job only downloads artifacts and does not check out the git repository.

## Root Cause

`gh release view`, `gh release create`, and `gh release upload` infer the target repository from the local git checkout unless `GH_REPO` or `--repo` is provided. The release job has no checkout, so tag-triggered release artifact uploads can fail with `fatal: not a git repository`.

## Validation

- Ran `git diff --check -- .github/workflows/ci.yml`
- Confirmed all `gh release` workflow steps now set `GH_REPO: ${{ github.repository }}`