### PR TITLE
[codex] Fix MMC3 sprite-fetch IRQ timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Notable release notes for `nes-py` are collected here from the
 
 - Added mapper-visible dummy sprite fetches for mappers that clock scanline IRQs
   from PPU A12 during the sprite-fetch phase.
+- Kept visible sprite rendering from emitting duplicate sprite-fetch address
+  observations, which keeps MMC3 IRQ split baselines stable when sprites move.
 - Fixed corrupted split-screen status bars in MMC3 titles such as
   Super Mario Bros. 3.
 - Added native PPU/MMC3 regression coverage for sprite-fetch address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Notable release notes for `nes-py` are collected here from the
 
 ## Unreleased
 
+## [9.0.1](https://github.com/Kautenja/nes-py/releases/tag/9.0.1) - 2026-06-10
+
+**Fix MMC3 sprite-fetch IRQ timing**
+
+- Added mapper-visible dummy sprite fetches for mappers that clock scanline IRQs
+  from PPU A12 during the sprite-fetch phase.
+- Fixed corrupted split-screen status bars in MMC3 titles such as
+  Super Mario Bros. 3.
+- Added native PPU/MMC3 regression coverage for sprite-fetch address
+  observations.
+
+**CPU compatibility**
+
 - Added CPU support for the undocumented `$DF` (`DCP absolute,X`) opcode used
   by some commercial NES ROM paths.
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,9 @@ python -m nes_py.speedtest --rom nes_py/tests/games/super-mario-bros-1.nes --vec
 9.  MMC2 / PxROM
 69. Sunsoft FME-7 / Sunsoft 5B
 
+MMC3 support includes PPU A12 observations during the sprite-fetch phase, which
+keeps scanline IRQ split-screen effects such as Super Mario Bros. 3 status bars
+aligned with the rendered frame.
 MMC5 vertical split rendering and MMC5 pulse/PCM audio are not implemented yet.
 Sunsoft 5B audio register state is preserved, but expansion-audio mixing is not
 implemented yet. Planned mapper expansion is tracked in the umbrella

--- a/nes_emu/include/nes_emu/mapper.hpp
+++ b/nes_emu/include/nes_emu/mapper.hpp
@@ -268,6 +268,12 @@ class Mapper {
         return false;
     }
 
+    /// Return true when this mapper needs PPU sprite-fetch address events even
+    /// when the renderer does not need to draw sprite pixels for a scanline.
+    inline virtual bool requiresPPUSpriteFetchAddressObservations() const {
+        return false;
+    }
+
     /// Observe a PPU read after data is resolved.
     inline virtual void onPPURead(NES_Address address, NES_Byte value) {
         (void) address;

--- a/nes_emu/include/nes_emu/mappers/mapper_MMC3.hpp
+++ b/nes_emu/include/nes_emu/mappers/mapper_MMC3.hpp
@@ -109,6 +109,11 @@ class MapperMMC3 : public Mapper {
         return true;
     }
 
+    /// MMC3 IRQ timing depends on sprite-fetch A12 edges.
+    inline bool requiresPPUSpriteFetchAddressObservations() const {
+        return true;
+    }
+
     /// Return true when a PRG-space write changes direct PRG read pages.
     bool invalidatesDirectPRGReadPagesOnWrite(
         NES_Address address,

--- a/nes_emu/include/nes_emu/picture_bus.hpp
+++ b/nes_emu/include/nes_emu/picture_bus.hpp
@@ -90,6 +90,14 @@ class PictureBus {
     ///
     NES_Byte read(NES_Address address);
 
+    /// Read sprite pattern data for visible pixel composition.
+    ///
+    /// Mappers such as MMC3 observe sprite-fetch addresses during the PPU's
+    /// sprite-fetch phase. Visible sprite composition must not emit another
+    /// mapper-visible PPU address for the same pattern data.
+    ///
+    NES_Byte read_sprite_pattern(NES_Address address);
+
     /// Write a byte to an address in the VRAM.
     ///
     /// @param address the 16-bit address to write the byte to in VRAM

--- a/nes_emu/include/nes_emu/picture_bus.hpp
+++ b/nes_emu/include/nes_emu/picture_bus.hpp
@@ -42,6 +42,7 @@ class PictureBus {
     bool mapper_has_name_table_mapping;
     bool mapper_allows_sprite_row_prefetch;
     bool mapper_allows_background_tile_cache_with_ppu_address_observations;
+    bool mapper_requires_ppu_sprite_fetch_address_observations;
     /// Direct CHR page pointers for mapper PPU read hot paths.
     std::array<const NES_Byte*, DIRECT_CHR_READ_PAGE_COUNT> direct_chr_read_pages;
     /// Incremented whenever CPU/PPU writes can invalidate cached render data.
@@ -74,6 +75,7 @@ class PictureBus {
         mapper_has_name_table_mapping(false),
         mapper_allows_sprite_row_prefetch(false),
         mapper_allows_background_tile_cache_with_ppu_address_observations(false),
+        mapper_requires_ppu_sprite_fetch_address_observations(false),
         direct_chr_read_pages{{
             nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr
@@ -120,6 +122,10 @@ class PictureBus {
             mapper != nullptr &&
             mapper->allowsBackgroundTileCacheWithPPUAddressObservations()
         );
+        mapper_requires_ppu_sprite_fetch_address_observations = (
+            mapper != nullptr &&
+            mapper->requiresPPUSpriteFetchAddressObservations()
+        );
         refresh_direct_chr_read_pages();
         update_mirroring();
     }
@@ -165,6 +171,11 @@ class PictureBus {
                 mapper_allows_background_tile_cache_with_ppu_address_observations
             )
         );
+    }
+
+    /// Return true when the mapper needs the PPU's sprite fetch address phase.
+    inline bool requires_sprite_fetch_address_observations() const {
+        return mapper_requires_ppu_sprite_fetch_address_observations;
     }
 
     /// Return the current write generation for render-cache invalidation.

--- a/nes_emu/include/nes_emu/ppu.hpp
+++ b/nes_emu/include/nes_emu/ppu.hpp
@@ -173,6 +173,10 @@ class PPU {
     /// Return the pattern address for a sprite row after vertical selection.
     NES_Address sprite_pattern_address(NES_Byte tile, int y_offset) const;
 
+    /// Emit mapper-visible sprite fetches that the simplified renderer does
+    /// not otherwise need for pixel composition.
+    void observe_dummy_sprite_fetch(PictureBus& bus) const;
+
     /// Prefetch rows for sprites selected for the next scanline.
     void prefetch_scanline_sprite_rows(PictureBus& bus);
 

--- a/nes_emu/src/nes_emu/picture_bus.cpp
+++ b/nes_emu/src/nes_emu/picture_bus.cpp
@@ -73,6 +73,25 @@ NES_Byte PictureBus::read(NES_Address address) {
     return 0;
 }
 
+NES_Byte PictureBus::read_sprite_pattern(NES_Address address) {
+    if (
+        !mapper_requires_ppu_sprite_fetch_address_observations ||
+        mapper_observes_ppu_reads ||
+        mapper_observes_ppu_writes ||
+        mapper_has_name_table_mapping
+    ) {
+        return read(address);
+    }
+
+    address &= 0x1fff;
+    const NES_Byte* direct_page = direct_chr_read_pages[
+        address / DIRECT_CHR_READ_PAGE_SIZE
+    ];
+    return direct_page == nullptr ?
+        mapper->readCHR(address) :
+        direct_page[address & (DIRECT_CHR_READ_PAGE_SIZE - 1)];
+}
+
 void PictureBus::write(NES_Address address, NES_Byte value) {
     address &= 0x3fff;
     if (address < 0x2000) {

--- a/nes_emu/src/nes_emu/ppu.cpp
+++ b/nes_emu/src/nes_emu/ppu.cpp
@@ -479,8 +479,15 @@ void PPU::cycle(PictureBus& bus) {
                             NES_Address address =
                                 sprite_pattern_address(tile, y_offset);
 
-                            sprColor = (bus.read(address) >> (x_shift)) & 1; //bit 0 of palette entry
-                            sprColor |= ((bus.read(address + 8) >> (x_shift)) & 1) << 1; //bit 1
+                            sprColor = (
+                                bus.read_sprite_pattern(address) >> (x_shift)
+                            ) & 1; //bit 0 of palette entry
+                            sprColor |= (
+                                (
+                                    bus.read_sprite_pattern(address + 8) >>
+                                    (x_shift)
+                                ) & 1
+                            ) << 1; //bit 1
 
                             if (!(sprOpaque = sprColor)) {
                                 sprColor = 0;

--- a/nes_emu/src/nes_emu/ppu.cpp
+++ b/nes_emu/src/nes_emu/ppu.cpp
@@ -191,6 +191,12 @@ NES_Address PPU::sprite_pattern_address(NES_Byte tile, int y_offset) const {
     return address;
 }
 
+void PPU::observe_dummy_sprite_fetch(PictureBus& bus) const {
+    const NES_Address address = sprite_pattern_address(0xff, 0);
+    bus.read(address);
+    bus.read(address + 8);
+}
+
 void PPU::prefetch_scanline_sprite_rows(PictureBus& bus) {
     std::fill(
         scanline_sprite_rows.begin(),
@@ -534,6 +540,13 @@ void PPU::cycle(PictureBus& bus) {
                 data_address &= ~0x41f;
                 data_address |= temp_address & 0x41f;
                 invalidate_background_tile_cache();
+            }
+            else if (
+                cycles == SCANLINE_VISIBLE_DOTS + 4 &&
+                is_showing_sprites &&
+                bus.requires_sprite_fetch_address_observations()
+            ) {
+                observe_dummy_sprite_fetch(bus);
             }
 
 //                 if (cycles > 257 && cycles < 320)

--- a/nes_emu/test/nes_emu/mappers/test_mapper_MMC3.cpp
+++ b/nes_emu/test/nes_emu/mappers/test_mapper_MMC3.cpp
@@ -135,6 +135,7 @@ TEST_CASE("mapper 004 MMC3 direct CHR pages stay valid with A12 observation", "[
     REQUIRE(mapper->observesPPUAddresses());
     REQUIRE(mapper->allowsDirectCHRReadWithPPUAddressObservations());
     REQUIRE(mapper->allowsBackgroundTileCacheWithPPUAddressObservations());
+    REQUIRE(mapper->requiresPPUSpriteFetchAddressObservations());
     REQUIRE(NESTest::direct_chr_read(*mapper, 0x0000) == NESTest::chr_kib_marker(0));
     REQUIRE(NESTest::direct_chr_read(*mapper, 0x0400) == NESTest::chr_kib_marker(1));
 

--- a/nes_emu/test/nes_emu/test_ppu_background_tile_rows.cpp
+++ b/nes_emu/test/nes_emu/test_ppu_background_tile_rows.cpp
@@ -5,6 +5,7 @@
 //  Copyright (c) 2019 Christian Kauten. All rights reserved.
 //
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <vector>
 #include "nes_emu/palette.hpp"
@@ -89,6 +90,13 @@ class CacheablePPUAddressMapper : public NESTest::PictureBusTestMapper {
     inline bool observesPPUAddresses() const { return true; }
 
     inline bool allowsBackgroundTileCacheWithPPUAddressObservations() const {
+        return true;
+    }
+};
+
+class SpriteFetchPPUAddressMapper : public NESTest::PPUHookMapper {
+ public:
+    inline bool requiresPPUSpriteFetchAddressObservations() const {
         return true;
     }
 };
@@ -265,4 +273,33 @@ TEST_CASE(
 
     REQUIRE(mapper.address_observations == 4);
     REQUIRE(mapper.address_sequence == expected);
+}
+
+TEST_CASE(
+    "PPU emits dummy sprite fetches for mappers that observe sprite A12",
+    "[ppu][sprite][mapper]"
+) {
+    SpriteFetchPPUAddressMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    hide_all_sprites(ppu);
+    ppu.control(0x08);
+
+    run_cycles(
+        ppu,
+        bus,
+        PRE_RENDER_CYCLES + NES::SCANLINE_VISIBLE_DOTS + 5
+    );
+
+    const auto low = std::find(
+        mapper.address_sequence.begin(),
+        mapper.address_sequence.end(),
+        0x1ff0
+    );
+    REQUIRE(low != mapper.address_sequence.end());
+    REQUIRE(std::next(low) != mapper.address_sequence.end());
+    REQUIRE(*std::next(low) == 0x1ff8);
 }

--- a/nes_emu/test/nes_emu/test_ppu_sprite_prefetch.cpp
+++ b/nes_emu/test/nes_emu/test_ppu_sprite_prefetch.cpp
@@ -6,6 +6,7 @@
 //
 
 #include <catch2/catch_test_macros.hpp>
+#include <vector>
 #include "nes_emu/palette.hpp"
 #include "nes_emu/picture_bus.hpp"
 #include "nes_emu/ppu.hpp"
@@ -28,6 +29,28 @@ class CountingSpriteMapper : public NESTest::ProgramTestMapper {
     inline NES::NES_Byte readCHR(NES::NES_Address address) {
         ++chr_reads;
         return NESTest::ProgramTestMapper::readCHR(address);
+    }
+};
+
+class SpriteFetchAddressMapper : public NESTest::PictureBusTestMapper {
+ public:
+    int address_observations;
+    std::vector<NES::NES_Address> address_sequence;
+
+    SpriteFetchAddressMapper() :
+        NESTest::PictureBusTestMapper(),
+        address_observations(0),
+        address_sequence() { }
+
+    inline void onPPUAddress(NES::NES_Address address) {
+        ++address_observations;
+        address_sequence.push_back(address);
+    }
+
+    inline bool observesPPUAddresses() const { return true; }
+
+    inline bool requiresPPUSpriteFetchAddressObservations() const {
+        return true;
     }
 };
 
@@ -225,4 +248,28 @@ TEST_CASE(
     REQUIRE(mapper.address_sequence[1] == 0x0018);
     REQUIRE(mapper.address_sequence[2] == 0x0010);
     REQUIRE(mapper.address_sequence[3] == 0x0018);
+}
+
+TEST_CASE(
+    "visible sprite composition does not clock sprite-fetch observers",
+    "[ppu][sprite][mapper]"
+) {
+    SpriteFetchAddressMapper mapper;
+    NES::PictureBus bus;
+    NES::PPU ppu;
+
+    bus.set_mapper(&mapper);
+    ppu.reset();
+    ppu.control(0x08);
+    ppu.set_mask(0x14);
+    hide_all_sprites(ppu);
+    write_sprite(ppu, 0, 0x00, 0x01, 0x00, 0x00);
+
+    run_cycles(ppu, bus, FIRST_SPRITE_SCANLINE_CYCLES);
+    REQUIRE(mapper.address_observations == 2);
+    REQUIRE(mapper.address_sequence[0] == 0x1ff0);
+    REQUIRE(mapper.address_sequence[1] == 0x1ff8);
+
+    run_cycles(ppu, bus, 8);
+    REQUIRE(mapper.address_observations == 2);
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "nes_py"
-version = "9.0.0"
+version = "9.0.1"
 description = "An NES Emulator and Gymnasium interface"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Add a mapper capability for PPU sprite-fetch address observations and enable it for MMC3.
- Emit mapper-visible dummy sprite fetches so MMC3 A12 scanline IRQ timing stays aligned even when no sprite pixels are drawn.
- Keep visible sprite rendering from emitting duplicate sprite-fetch address observations, which stabilizes SMB3 status-bar split baselines while sprites move.
- Document the fix, add native PPU/MMC3 regression coverage, and bump `nes_py` to `9.0.1`.

## Root Cause

The renderer only fetched sprite pattern data when it needed sprite pixels for composition. MMC3 titles also depend on the PPU sprite-fetch phase to produce A12 transitions for scanline IRQ timing. Without those mapper-visible fetches, split-screen effects such as the Super Mario Bros. 3 status bar could select the wrong CHR bank and render garbled HUD tiles.

After adding the sprite-fetch phase, visible sprite composition still performed mapper-visible CHR reads while drawing pixels. Those extra A12 observations depended on sprite positions, so SMB3's split IRQ could drift vertically during gameplay. Sprite drawing now reads pattern bytes without producing another mapper-visible sprite-fetch address event when the mapper already requested the dedicated sprite-fetch phase.

## Validation

- `build/nes-emu-debug/nes_emu_tests`
- `PYTHONPATH=/Users/christiankauten/Documents/Projects/gym-nes/nes-py /Users/christiankauten/Documents/Projects/gym-nes/gym-super-mario-bros/.venv/bin/python -m unittest discover`
- `PYTHONPATH=/Users/christiankauten/Documents/Projects/gym-nes/gym-super-mario-bros:/Users/christiankauten/Documents/Projects/gym-nes/nes-py /Users/christiankauten/Documents/Projects/gym-nes/gym-super-mario-bros/.venv/bin/python -m unittest discover`
- Verified editable package metadata reports `nes_py` version `9.0.1`.
